### PR TITLE
The Navigationing

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookContentScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookContentScreen.java
@@ -152,21 +152,6 @@ public class BookContentScreen extends BookPaginatedScreen {
         return left ? this.openPagesIndex > 0 : (this.openPagesIndex + 2) < this.unlockedPages.size();
     }
 
-    public boolean canSeeBackButton() {
-        return BookGuiManager.get().getHistorySize() > 0;
-    }
-
-    public void handleBackButton(Button button) {
-        this.back();
-    }
-
-    public void back() {
-        if (BookGuiManager.get().getHistorySize() > 0) {
-            var lastPage = BookGuiManager.get().popHistory();
-            BookGuiManager.get().openEntry(lastPage.bookId, lastPage.categoryId, lastPage.entryId, lastPage.page);
-        }
-    }
-
     public void setTooltip(Component... strings) {
         this.setTooltip(List.of(strings));
     }

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookContentScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookContentScreen.java
@@ -49,7 +49,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.crafting.Ingredient;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.Arrays;
@@ -332,8 +332,7 @@ public class BookContentScreen extends BookPaginatedScreen {
         return this.bookTop;
     }
 
-    @SuppressWarnings("unchecked")
-    public void removeRenderableWidgets(Collection<? extends Renderable> renderables) {
+    public void removeRenderableWidgets(@NotNull Collection<? extends Renderable> renderables) {
         this.renderables.removeIf(renderables::contains);
         this.children().removeIf(c -> c instanceof Renderable && renderables.contains(c));
         this.narratables.removeIf(n -> n instanceof Renderable && renderables.contains(n));

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookContentScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookContentScreen.java
@@ -321,8 +321,7 @@ public class BookContentScreen extends BookPaginatedScreen {
         if (leftPageClickedStyle != null) {
             return leftPageClickedStyle;
         }
-        var rightPageClickedStyle = this.getClickedComponentStyleAtForPage(this.rightPageRenderer, pMouseX, pMouseY);
-        return rightPageClickedStyle;
+		return this.getClickedComponentStyleAtForPage(this.rightPageRenderer, pMouseX, pMouseY);
     }
 
     public int getBookLeft() {
@@ -340,40 +339,15 @@ public class BookContentScreen extends BookPaginatedScreen {
         this.narratables.removeIf(n -> n instanceof Renderable && renderables.contains(n));
     }
 
-    private int getCurrentPageIndex() {
-        return this.leftPage != null ? this.leftPage.getPageNumber()
-                : this.rightPage != null ? this.rightPage.getPageNumber()
-                : 0;
-    }
-
     protected void flipPage(boolean left, boolean playSound) {
         if (this.canSeeArrowButton(left)) {
-
-            var currentPageIndex = this.unlockedPages.get(this.openPagesIndex).getPageNumber();
-
+            
             if (left) {
                 this.openPagesIndex -= 2;
             } else {
                 this.openPagesIndex += 2;
             }
-
-            var newPageIndex = this.unlockedPages.get(this.openPagesIndex).getPageNumber();
-
-            if (BookGuiManager.get().getHistorySize() > 0) {
-                var lastPage = BookGuiManager.get().peekHistory();
-                if (lastPage.bookId == this.entry.getBook().getId() && lastPage.entryId == this.entry.getId() && lastPage.page == newPageIndex) {
-                    //if we're flipping back to the last page in the history, don't add a new history entry,
-                    // and remove the old one to avoid weird back-and-forth jumps when using the back button
-                    BookGuiManager.get().popHistory();
-                } else {
-                    //if we flip to a new page, add a new history entry for the page we were on before flipping
-                    BookGuiManager.get().pushHistory(this.entry.getBook().getId(), this.entry.getCategory().getId(), this.entry.getId(), currentPageIndex);
-                }
-            } else {
-                //if we don't have any history, add a new history entry for the page we were on before flipping
-                BookGuiManager.get().pushHistory(this.entry.getBook().getId(), this.entry.getCategory().getId(), this.entry.getId(), currentPageIndex);
-            }
-
+            
             this.onPageChanged();
             if (playSound) {
                 playTurnPageSound(this.getBook());

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookPaginatedScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookPaginatedScreen.java
@@ -1,0 +1,106 @@
+package com.klikli_dev.modonomicon.client.gui.book;
+
+import com.klikli_dev.modonomicon.client.gui.*;
+import com.klikli_dev.modonomicon.client.gui.book.button.*;
+import net.minecraft.client.gui.components.*;
+import net.minecraft.client.gui.screens.*;
+import net.minecraft.network.chat.*;
+import org.lwjgl.glfw.*;
+
+public abstract class BookPaginatedScreen extends Screen implements BookScreenWithButtons {
+	
+	public static final int FULL_WIDTH = 272;
+	public static final int FULL_HEIGHT = 180;
+	
+	public static final int BOOK_BACKGROUND_WIDTH = 272;
+	public static final int BOOK_BACKGROUND_HEIGHT = 178;
+	
+	protected final BookOverviewScreen parentScreen;
+	
+	protected int bookLeft;
+	protected int bookTop;
+	
+	public BookPaginatedScreen(Component component, BookOverviewScreen parentScreen) {
+		super(component);
+		
+		this.parentScreen = parentScreen;
+	}
+	
+	@Override
+	protected void init() {
+		super.init();
+		
+		this.bookLeft = (this.width - BOOK_BACKGROUND_WIDTH) / 2;
+		this.bookTop = (this.height - BOOK_BACKGROUND_HEIGHT) / 2;
+
+		this.addRenderableWidget(new ArrowButton(this, this.bookLeft - 4, this.bookTop + FULL_HEIGHT - 6, true, () -> this.canSeeArrowButton(true), this::handleArrowButton));
+		this.addRenderableWidget(new ArrowButton(this, this.bookLeft + FULL_WIDTH - 14, this.bookTop + FULL_HEIGHT - 6, false, () -> this.canSeeArrowButton(false), this::handleArrowButton));
+		this.addRenderableWidget(new ExitButton(this, this.bookLeft + FULL_WIDTH - 10, this.bookTop - 2, this::handleExitButton));
+	}
+	
+	public void handleExitButton(Button button) {
+		this.onClose();
+	}
+	
+	public abstract boolean canSeeArrowButton(boolean left);
+	
+	/**
+	 * Needs to use Button instead of ArrowButton to conform to Button.OnPress otherwise we can't use it as method
+	 * reference, which we need - lambda can't use this in super constructor call.
+	 */
+	public void handleArrowButton(Button button) {
+		this.flipPage(((ArrowButton) button).left, true);
+	}
+	
+	protected abstract void flipPage(boolean left, boolean playSound);
+	
+	protected boolean isClickOutsideEntry(double pMouseX, double pMouseY) {
+		return pMouseX < this.bookLeft - BookContentScreen.CLICK_SAFETY_MARGIN
+				|| pMouseX > this.bookLeft + BookContentScreen.FULL_WIDTH + BookContentScreen.CLICK_SAFETY_MARGIN
+				|| pMouseY < this.bookTop - BookContentScreen.CLICK_SAFETY_MARGIN
+				|| pMouseY > this.bookTop + BookContentScreen.FULL_HEIGHT + BookContentScreen.CLICK_SAFETY_MARGIN;
+	}
+	
+	@Override
+	public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+		if (keyCode == GLFW.GLFW_KEY_BACKSPACE) {
+			this.back();
+			return true;
+		}
+		
+		return super.keyPressed(keyCode, scanCode, modifiers);
+	}
+	
+	public void back() {
+		if (BookGuiManager.get().getHistorySize() > 0) {
+			var lastPage = BookGuiManager.get().popHistory();
+			BookGuiManager.get().openEntry(lastPage.bookId, lastPage.categoryId, lastPage.entryId, lastPage.page);
+		}
+	}
+	
+	@Override
+	public boolean mouseClicked(double pMouseX, double pMouseY, int pButton) {
+		if (this.isClickOutsideEntry(pMouseX, pMouseY)) {
+			this.onClose();
+		}
+		
+		if (pButton == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+			this.back();
+			return true;
+		}
+		
+		return super.mouseClicked(pMouseX, pMouseY, pButton);
+	}
+	
+	@Override
+	public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
+		if (delta < 0) {
+			this.flipPage(false, true);
+		} else if (delta > 0) {
+			this.flipPage(true, true);
+		}
+		
+		return true;
+	}
+	
+}

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookPaginatedScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookPaginatedScreen.java
@@ -71,10 +71,20 @@ public abstract class BookPaginatedScreen extends Screen implements BookScreenWi
 		return super.keyPressed(keyCode, scanCode, modifiers);
 	}
 	
+	public boolean canSeeBackButton() {
+		return BookGuiManager.get().getHistorySize() > 0;
+	}
+	
+	public void handleBackButton(Button button) {
+		this.back();
+	}
+	
 	public void back() {
 		if (BookGuiManager.get().getHistorySize() > 0) {
 			var lastPage = BookGuiManager.get().popHistory();
 			BookGuiManager.get().openEntry(lastPage.bookId, lastPage.categoryId, lastPage.entryId, lastPage.page);
+		} else {
+			this.onClose();
 		}
 	}
 	

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookSearchScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookSearchScreen.java
@@ -8,30 +8,24 @@
 package com.klikli_dev.modonomicon.client.gui.book;
 
 import com.klikli_dev.modonomicon.api.ModonomiconConstants.I18n.Gui;
-import com.klikli_dev.modonomicon.book.Book;
-import com.klikli_dev.modonomicon.book.BookEntry;
-import com.klikli_dev.modonomicon.book.BookTextHolder;
-import com.klikli_dev.modonomicon.book.RenderedBookTextHolder;
-import com.klikli_dev.modonomicon.bookstate.BookUnlockStateManager;
-import com.klikli_dev.modonomicon.client.gui.BookGuiManager;
-import com.klikli_dev.modonomicon.client.gui.book.button.ArrowButton;
-import com.klikli_dev.modonomicon.client.gui.book.button.EntryListButton;
-import com.klikli_dev.modonomicon.client.gui.book.button.ExitButton;
-import com.klikli_dev.modonomicon.client.gui.book.markdown.BookTextRenderer;
-import com.klikli_dev.modonomicon.client.render.page.BookPageRenderer;
-import com.klikli_dev.modonomicon.util.GuiGraphicsExt;
-import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.EditBox;
-import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.Component;
-import org.lwjgl.glfw.GLFW;
+import com.klikli_dev.modonomicon.book.*;
+import com.klikli_dev.modonomicon.bookstate.*;
+import com.klikli_dev.modonomicon.client.gui.*;
+import com.klikli_dev.modonomicon.client.gui.book.button.*;
+import com.klikli_dev.modonomicon.client.gui.book.markdown.*;
+import com.klikli_dev.modonomicon.client.render.page.*;
+import com.klikli_dev.modonomicon.platform.*;
+import com.klikli_dev.modonomicon.util.*;
+import com.mojang.blaze3d.platform.*;
+import com.mojang.blaze3d.systems.*;
+import net.minecraft.client.*;
+import net.minecraft.client.gui.*;
+import net.minecraft.client.gui.components.*;
+import net.minecraft.client.resources.language.*;
+import net.minecraft.network.chat.*;
+import org.lwjgl.glfw.*;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 public class BookSearchScreen extends BookPaginatedScreen {
     public static final int ENTRIES_PER_PAGE = 13;
@@ -238,6 +232,17 @@ public class BookSearchScreen extends BookPaginatedScreen {
         super.render(guiGraphics, pMouseX, pMouseY, pPartialTick);
 
         this.drawTooltip(guiGraphics, pMouseX, pMouseY);
+    }
+    
+    
+    @Override
+    public void onClose() {
+        if (InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), GLFW.GLFW_KEY_ESCAPE)) {
+            super.onClose();
+            this.parentScreen.onClose();
+        } else {
+            ClientServices.GUI.popGuiLayer(); //instead of super.onClose() to restore our parent screen
+        }
     }
 
     @Override


### PR DESCRIPTION
## Why?
Lots of the mouse and keyboard gestures in BookContentScreen could not be used in BookSearchScreen. There also were some inconsistencies that felt unintutive that have been unified in this PR.

## How?
Since BookContentScreen and BookSearchScreen were kind of similar internally and used quite a bit of identical code, I introduced BookPaginatedScreen as a super class and pulled up all of the relevant methods.
Most code from BookContentScreen that handled navigation was unified to match both cases and some additional gestures introduced or changed.

## Changes
**Both Content and Search screens can now**
- Be navigated back and forth using scroll wheel (identical to back/forward buttons)
- The exit button now opens the last chapter (book was closed when using the search page before)
- Pressing backspace works for both, following the same logic as the exit button
- The "back" button always opens the last entry. If the stack is empty the player is returned to the last open chapter
  - the search entry is not added to the stack and will be skipped instead
  - if opening an entry using search, the player will be returned to the category with that entry