### PR TITLE
Use FastUtil instead of regular Java collections

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/api/datagen/BookProvider.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/api/datagen/BookProvider.java
@@ -13,6 +13,7 @@ import com.klikli_dev.modonomicon.api.datagen.book.BookCommandModel;
 import com.klikli_dev.modonomicon.api.datagen.book.BookEntryModel;
 import com.klikli_dev.modonomicon.api.datagen.book.BookModel;
 import com.mojang.logging.LogUtils;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
@@ -22,11 +23,21 @@ import org.slf4j.Logger;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collector;
+import java.util.stream.Collector.Characteristics;
 import java.util.stream.Stream;
 
 public abstract class BookProvider implements DataProvider {
 
     protected static final Logger LOGGER = LogUtils.getLogger();
+    
+    public static final Collector<ModonomiconLanguageProvider, ?, Object2ObjectOpenHashMap<String, ModonomiconLanguageProvider>> mapMaker
+            = Collector.<ModonomiconLanguageProvider, Object2ObjectOpenHashMap<String, ModonomiconLanguageProvider>, Object2ObjectOpenHashMap<String, ModonomiconLanguageProvider>>of(
+                    Object2ObjectOpenHashMap::new,
+                    (map, l) -> map.put(l.locale(), l),
+                    (m1, m2) -> { m1.putAll(m2); return m1; },
+                    (map) -> { map.trim(); return map; },
+                    Characteristics.UNORDERED);
 
     protected final PackOutput packOutput;
     protected final ModonomiconLanguageProvider lang;
@@ -47,12 +58,13 @@ public abstract class BookProvider implements DataProvider {
         this.modid = modid;
         this.packOutput = packOutput;
         this.lang = defaultLang;
-        this.bookModels = new HashMap<>();
-        this.translations = Stream.concat(Arrays.stream(translations), Stream.of(defaultLang)).map(l -> new AbstractMap.SimpleEntry<>(l.locale(), l)).collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
+        this.bookModels = new Object2ObjectOpenHashMap<>();
+        this.translations = Stream.concat(Arrays.stream(translations), Stream.of(defaultLang))
+                                  .collect(mapMaker);
 
         this.bookId = bookId;
         this.context = new BookContextHelper(this.modid);
-        this.defaultMacros = new HashMap<>();
+        this.defaultMacros = new Object2ObjectOpenHashMap<>();
         this.conditionHelper = new ConditionHelper();
     }
 

--- a/common/src/main/java/com/klikli_dev/modonomicon/api/datagen/CategoryProvider.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/api/datagen/CategoryProvider.java
@@ -13,6 +13,7 @@ import com.klikli_dev.modonomicon.api.datagen.book.condition.BookAndConditionMod
 import com.klikli_dev.modonomicon.api.datagen.book.condition.BookConditionModel;
 import com.klikli_dev.modonomicon.api.datagen.book.condition.BookOrConditionModel;
 import com.klikli_dev.modonomicon.api.datagen.book.page.BookPageModel;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ItemLike;
@@ -39,7 +40,7 @@ public abstract class CategoryProvider {
         this.parent = parent;
         this.categoryId = categoryId;
         this.entryMap = new CategoryEntryMap();
-        this.macros = new HashMap<>();
+        this.macros = new Object2ObjectOpenHashMap<>();
         this.conditionHelper = new ConditionHelper();
         this.category = null;
     }
@@ -204,7 +205,7 @@ public abstract class CategoryProvider {
         return entry;
     }
 
-    protected Map<String, List<BookPageModel>> cachedPages = new HashMap<>();
+    protected Map<String, List<BookPageModel>> cachedPages = new Object2ObjectOpenHashMap<>();
 
     /**
      * Adds a page to the cached pages of this category provider.

--- a/common/src/main/java/com/klikli_dev/modonomicon/api/datagen/LanguageProviderCache.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/api/datagen/LanguageProviderCache.java
@@ -4,6 +4,7 @@
 
 package com.klikli_dev.modonomicon.api.datagen;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
@@ -11,14 +12,13 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.block.Block;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
 public class LanguageProviderCache implements ModonomiconLanguageProvider {
 
     private final String locale;
-    private final Map<String, String> data = new HashMap<>();
+    private final Map<String, String> data = new Object2ObjectOpenHashMap<>();
 
     public LanguageProviderCache(String locale) {
         this.locale = locale;

--- a/common/src/main/java/com/klikli_dev/modonomicon/bookstate/BookUnlockStates.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/bookstate/BookUnlockStates.java
@@ -22,6 +22,8 @@ import com.klikli_dev.modonomicon.util.Codecs;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.buffer.Unpooled;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -97,7 +99,7 @@ public class BookUnlockStates {
                 try {
                     var categoryContext = BookConditionContext.of(book, category);
                     if (category.getCondition().test(categoryContext, owner))
-                        this.unlockedCategories.computeIfAbsent(book.getId(), k -> new HashSet<>()).add(category.getId());
+                        this.unlockedCategories.computeIfAbsent(book.getId(), k -> new ObjectOpenHashSet<>()).add(category.getId());
                     else if (category.getCondition().requiresMultiPassUnlockTest())
                         //if the condition is not met AND it requires a multi pass unlock test we store it to test again later
                         //this is because if the condition depends on an unlock that may happen later in the first pass it should unlock this condition alongside
@@ -114,7 +116,7 @@ public class BookUnlockStates {
                     try {
                         var entryContext = BookConditionContext.of(book, entry);
                         if (entry.getCondition().test(entryContext, owner))
-                            this.unlockedEntries.computeIfAbsent(book.getId(), k -> new HashSet<>()).add(entry.getId());
+                            this.unlockedEntries.computeIfAbsent(book.getId(), k -> new ObjectOpenHashSet<>()).add(entry.getId());
                         else if (entry.getCondition().requiresMultiPassUnlockTest())
                             //if the condition is not met AND it requires a multi pass unlock test we store it to test again later
                             //this is because if the condition depends on an unlock that may happen later in the first pass it should unlock this condition alongside
@@ -132,11 +134,11 @@ public class BookUnlockStates {
                             var pageContext = BookConditionContext.of(book, page);
                             var pageCondition = page.getCondition();
                             if (pageCondition.test(pageContext, owner)) {
-                                var pages = this.unlockedPages.computeIfAbsent(book.getId(), k -> new HashMap<>())
-                                        .computeIfAbsent(entry.getId(), k -> new HashSet<>());
+                                var pages = this.unlockedPages.computeIfAbsent(book.getId(), k -> new Object2ObjectOpenHashMap<>())
+                                        .computeIfAbsent(entry.getId(), k -> new ObjectOpenHashSet<>());
                                 if (!pages.contains(page.getPageNumber())) {
                                      pages.add(page.getPageNumber());
-                                    this.readEntries.computeIfAbsent(book.getId(), k -> new HashSet<>()).remove(entry.getId());
+                                    this.readEntries.computeIfAbsent(book.getId(), k -> new ObjectOpenHashSet<>()).remove(entry.getId());
                                 }
                             } else if (pageCondition.requiresMultiPassUnlockTest()) {
                                 //if the condition is not met AND it requires a multi pass unlock test we store it to test again later
@@ -169,16 +171,16 @@ public class BookUnlockStates {
                     try {
                         //then store the unlock result
                         if (condition.getValue() instanceof BookConditionPageContext pageContext) {
-                            var pages = this.unlockedPages.computeIfAbsent(pageContext.getBook().getId(), k -> new HashMap<>())
-                                    .computeIfAbsent(pageContext.getEntry().getId(), k -> new HashSet<>());
+                            var pages = this.unlockedPages.computeIfAbsent(pageContext.getBook().getId(), k -> new Object2ObjectOpenHashMap<>())
+                                    .computeIfAbsent(pageContext.getEntry().getId(), k -> new ObjectOpenHashSet<>());
                             if (!pages.contains(pageContext.getPage().getPageNumber())) {
                                 pages.add(pageContext.getPage().getPageNumber());
-                                this.readEntries.computeIfAbsent(pageContext.getBook().getId(), k -> new HashSet<>()).remove(pageContext.getEntry().getId());
+                                this.readEntries.computeIfAbsent(pageContext.getBook().getId(), k -> new ObjectOpenHashSet<>()).remove(pageContext.getEntry().getId());
                             }
                         } else if (condition.getValue() instanceof BookConditionEntryContext entryContext) {
-                            this.unlockedEntries.computeIfAbsent(entryContext.getBook().getId(), k -> new HashSet<>()).add(entryContext.getEntry().getId());
+                            this.unlockedEntries.computeIfAbsent(entryContext.getBook().getId(), k -> new ObjectOpenHashSet<>()).add(entryContext.getEntry().getId());
                         } else if (condition.getValue() instanceof BookConditionCategoryContext categoryContext) {
-                            this.unlockedCategories.computeIfAbsent(categoryContext.getBook().getId(), k -> new HashSet<>()).add(categoryContext.getCategory().getId());
+                            this.unlockedCategories.computeIfAbsent(categoryContext.getBook().getId(), k -> new ObjectOpenHashSet<>()).add(categoryContext.getCategory().getId());
                         }
 
                         //make sure to iterate again now -> could unlock further conditions depending on this unlock
@@ -207,7 +209,7 @@ public class BookUnlockStates {
         if (this.isRead(entry))
             return false;
 
-        this.readEntries.computeIfAbsent(entry.getBook().getId(), k -> new HashSet<>()).add(entry.getId());
+        this.readEntries.computeIfAbsent(entry.getBook().getId(), k -> new ObjectOpenHashSet<>()).add(entry.getId());
 
         var command = entry.getCommandToRunOnFirstRead();
         if (command != null) {
@@ -221,8 +223,8 @@ public class BookUnlockStates {
         if (command.getBook() == null)
             return;
 
-        var uses = this.usedCommands.getOrDefault(command.getBook().getId(), new HashMap<>()).getOrDefault(command.getId(), 0);
-        this.usedCommands.computeIfAbsent(command.getBook().getId(), k -> new HashMap<>()).put(command.getId(), uses + 1);
+        var uses = this.usedCommands.getOrDefault(command.getBook().getId(), new Object2ObjectOpenHashMap<>()).getOrDefault(command.getId(), 0);
+        this.usedCommands.computeIfAbsent(command.getBook().getId(), k -> new Object2ObjectOpenHashMap<>()).put(command.getId(), uses + 1);
     }
 
     public boolean canRun(BookCommand command) {
@@ -232,39 +234,39 @@ public class BookUnlockStates {
         if (command.getMaxUses() == -1) //unlimited uses
             return true;
 
-        return this.usedCommands.getOrDefault(command.getBook().getId(), new HashMap<>()).getOrDefault(command.getId(), 0) < command.getMaxUses();
+        return this.usedCommands.getOrDefault(command.getBook().getId(), new Object2ObjectOpenHashMap<>()).getOrDefault(command.getId(), 0) < command.getMaxUses();
     }
 
     public boolean isRead(BookEntry entry) {
         if (entry.getBook() == null)
             return false;
-        return this.readEntries.getOrDefault(entry.getBook().getId(), new HashSet<>()).contains(entry.getId());
+        return this.readEntries.getOrDefault(entry.getBook().getId(), new ObjectOpenHashSet<>()).contains(entry.getId());
     }
 
     public List<BookPage> getUnlockedPagesIn(BookEntry entry) {
-        var unlockedPageNumbers = this.unlockedPages.getOrDefault(entry.getBook().getId(), new HashMap<>())
-                .getOrDefault(entry.getId(), new HashSet<>());
+        var unlockedPageNumbers = this.unlockedPages.getOrDefault(entry.getBook().getId(), new Object2ObjectOpenHashMap<>())
+                .getOrDefault(entry.getId(), new ObjectOpenHashSet<>());
         return entry.getPages().stream().filter(page -> unlockedPageNumbers.contains(page.getPageNumber())).toList();
     }
 
     public boolean isUnlocked(BookPage page) {
         if (page.getBook() == null)
             return false;
-        return this.unlockedPages.getOrDefault(page.getBook().getId(), new HashMap<>())
-                .getOrDefault(page.getParentEntry().getId(), new HashSet<>())
+        return this.unlockedPages.getOrDefault(page.getBook().getId(), new Object2ObjectOpenHashMap<>())
+                .getOrDefault(page.getParentEntry().getId(), new ObjectOpenHashSet<>())
                 .contains(page.getPageNumber());
     }
 
     public boolean isUnlocked(BookEntry entry) {
         if (entry.getBook() == null)
             return false;
-        return this.unlockedEntries.getOrDefault(entry.getBook().getId(), new HashSet<>()).contains(entry.getId());
+        return this.unlockedEntries.getOrDefault(entry.getBook().getId(), new ObjectOpenHashSet<>()).contains(entry.getId());
     }
 
     public boolean isUnlocked(BookCategory category) {
         if (category.getBook() == null)
             return false;
-        return this.unlockedCategories.getOrDefault(category.getBook().getId(), new HashSet<>()).contains(category.getId());
+        return this.unlockedCategories.getOrDefault(category.getBook().getId(), new ObjectOpenHashSet<>()).contains(category.getId());
     }
 
     public void reset(Book book) {
@@ -276,7 +278,7 @@ public class BookUnlockStates {
     }
 
     public List<ResourceLocation> getBooks() {
-        var books = new HashSet<ResourceLocation>();
+        var books = new ObjectOpenHashSet<ResourceLocation>();
         books.addAll(this.readEntries.keySet());
         books.addAll(this.unlockedPages.keySet());
         books.addAll(this.unlockedEntries.keySet());
@@ -324,10 +326,10 @@ public class BookUnlockStates {
             if (book == null)
                 return null;
 
-            var unlockedCategories = new HashSet<ResourceLocation>();
-            var unlockedEntries = new HashSet<ResourceLocation>();
-            var unlockedPages = new HashMap<ResourceLocation, Set<Integer>>();
-            var readEntries = new HashSet<ResourceLocation>();
+            var unlockedCategories = new ObjectOpenHashSet<ResourceLocation>();
+            var unlockedEntries = new ObjectOpenHashSet<ResourceLocation>();
+            var unlockedPages = new Object2ObjectOpenHashMap<ResourceLocation, Set<Integer>>();
+            var readEntries = new ObjectOpenHashSet<ResourceLocation>();
 
             var unlockedCategoriesSize = buf.readVarInt();
             for (var i = 0; i < unlockedCategoriesSize; i++) {
@@ -342,7 +344,7 @@ public class BookUnlockStates {
             var unlockedPagesSize = buf.readVarInt();
             for (var i = 0; i < unlockedPagesSize; i++) {
                 var entryId = buf.readResourceLocation();
-                var unlockedPagesForEntry = new HashSet<Integer>();
+                var unlockedPagesForEntry = new ObjectOpenHashSet<Integer>();
                 unlockedPages.put(entryId, unlockedPagesForEntry);
 
                 var pagesSize = buf.readVarInt();
@@ -355,7 +357,12 @@ public class BookUnlockStates {
             for (var i = 0; i < readEntriesSize; i++) {
                 readEntries.add(buf.readResourceLocation());
             }
-
+            
+            unlockedCategories.trim();
+            unlockedPages.trim();
+            unlockedPages.trim();
+            readEntries.trim();
+            
             this.unlockedCategories.put(bookId, unlockedCategories);
             this.unlockedEntries.put(bookId, unlockedEntries);
             this.unlockedPages.put(bookId, unlockedPages);

--- a/common/src/main/java/com/klikli_dev/modonomicon/bookstate/visual/BookVisualState.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/bookstate/visual/BookVisualState.java
@@ -9,9 +9,10 @@ package com.klikli_dev.modonomicon.bookstate.visual;
 import com.klikli_dev.modonomicon.util.Codecs;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMaps;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.resources.ResourceLocation;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -25,12 +26,12 @@ public class BookVisualState {
     public ResourceLocation openCategory;
 
     public BookVisualState() {
-        this(new HashMap<>(), Optional.empty());
+        this(Object2ObjectMaps.emptyMap(), Optional.empty());
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public BookVisualState(Map<ResourceLocation, CategoryVisualState> categoryStates, Optional<ResourceLocation> openCategory) {
-        this.categoryStates = new HashMap<>(categoryStates);
+        this.categoryStates = new Object2ObjectOpenHashMap<>(categoryStates);
         this.openCategory = openCategory.orElse(null);
     }
 }

--- a/common/src/main/java/com/klikli_dev/modonomicon/bookstate/visual/CategoryVisualState.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/bookstate/visual/CategoryVisualState.java
@@ -9,9 +9,9 @@ package com.klikli_dev.modonomicon.bookstate.visual;
 import com.klikli_dev.modonomicon.util.Codecs;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.resources.ResourceLocation;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -34,7 +34,7 @@ public class CategoryVisualState {
     public ResourceLocation openEntry;
 
     public CategoryVisualState() {
-        this(new HashMap<>(), 0, 0, 0.7f, Optional.empty());
+        this(new Object2ObjectOpenHashMap<>(), 0, 0, 0.7f, Optional.empty());
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/CoreComponentNodeRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/CoreComponentNodeRenderer.java
@@ -7,6 +7,7 @@
 package com.klikli_dev.modonomicon.client.gui.book.markdown;
 
 import com.klikli_dev.modonomicon.api.ModonomiconConstants.I18n.Gui;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.ClickEvent.Action;
 import net.minecraft.network.chat.Component;
@@ -18,7 +19,6 @@ import org.commonmark.node.*;
 import org.commonmark.renderer.NodeRenderer;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 public class CoreComponentNodeRenderer extends AbstractVisitor implements NodeRenderer {
@@ -32,7 +32,7 @@ public class CoreComponentNodeRenderer extends AbstractVisitor implements NodeRe
     @Override
     public Set<Class<? extends Node>> getNodeTypes() {
         //we need to return nodes here even if we don't do special handling, otherwise they will be skipped.
-        return new HashSet<>(Arrays.asList(
+        ObjectOpenHashSet<Class<? extends Node>> classes = new ObjectOpenHashSet<>(Arrays.asList(
                 Document.class,
                 Heading.class,
                 Paragraph.class,
@@ -44,8 +44,9 @@ public class CoreComponentNodeRenderer extends AbstractVisitor implements NodeRe
                 StrongEmphasis.class,
                 Text.class,
                 SoftLineBreak.class,
-                HardLineBreak.class
-        ));
+                HardLineBreak.class));
+        classes.trim();
+        return classes;
     }
 
     public void render(Node node) {

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/MultiblockPreviewRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/MultiblockPreviewRenderer.java
@@ -24,6 +24,7 @@ import com.mojang.blaze3d.vertex.*;
 import com.mojang.blaze3d.vertex.VertexFormat.Mode;
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -60,7 +61,7 @@ public class MultiblockPreviewRenderer {
 
     public static boolean hasMultiblock;
 
-    private static Map<BlockPos, BlockEntity> blockEntityCache = new HashMap<>();
+    private static Map<BlockPos, BlockEntity> blockEntityCache = new Object2ObjectOpenHashMap<>();
     private static Set<BlockEntity> erroredBlockEntities = Collections.newSetFromMap(new WeakHashMap<>());
     private static Multiblock multiblock;
     private static Component name;

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/page/BookMultiblockPageRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/page/BookMultiblockPageRenderer.java
@@ -21,6 +21,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.math.Axis;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -47,7 +48,7 @@ import java.util.*;
 public class BookMultiblockPageRenderer extends BookPageRenderer<BookMultiblockPage> implements PageWithTextRenderer {
 
     private static final RandomSource randomSource = RandomSource.createNewThreadLocalInstance();
-    private final Map<BlockPos, BlockEntity> blockEntityCache = new HashMap<>();
+    private final Map<BlockPos, BlockEntity> blockEntityCache = new Object2ObjectOpenHashMap<>();
     private final Set<BlockEntity> erroredBlockEntities = Collections.newSetFromMap(new WeakHashMap<>());
 
     protected Pair<BlockPos, Collection<SimulateResult>> multiblockSimulation;

--- a/common/src/main/java/com/klikli_dev/modonomicon/multiblock/AbstractMultiblock.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/multiblock/AbstractMultiblock.java
@@ -13,6 +13,7 @@ import com.klikli_dev.modonomicon.api.multiblock.StateMatcher;
 import com.klikli_dev.modonomicon.api.multiblock.TriPredicate;
 import com.klikli_dev.modonomicon.data.LoaderRegistry;
 import com.mojang.datafixers.util.Pair;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
@@ -37,7 +38,7 @@ import java.util.Map.Entry;
 
 public abstract class AbstractMultiblock implements Multiblock {
 
-    private final Map<BlockPos, BlockEntity> blockEntityCache = new HashMap<>();
+    private final Map<BlockPos, BlockEntity> blockEntityCache = new Object2ObjectOpenHashMap<>();
     public ResourceLocation id;
     protected int offX, offY, offZ;
     protected int viewOffX, viewOffY, viewOffZ;

--- a/common/src/main/java/com/klikli_dev/modonomicon/multiblock/DenseMultiblock.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/multiblock/DenseMultiblock.java
@@ -16,6 +16,7 @@ import com.klikli_dev.modonomicon.api.multiblock.TriPredicate;
 import com.klikli_dev.modonomicon.data.LoaderRegistry;
 import com.klikli_dev.modonomicon.multiblock.matcher.Matchers;
 import com.mojang.datafixers.util.Pair;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.network.FriendlyByteBuf;
@@ -78,7 +79,7 @@ public class DenseMultiblock extends AbstractMultiblock {
             }
         }
 
-        var targets = new HashMap<Character, StateMatcher>();
+        var targets = new Object2ObjectOpenHashMap<Character, StateMatcher>();
         var targetCount = buffer.readVarInt();
         for (int i = 0; i < targetCount; i++) {
             var key = buffer.readChar();

--- a/common/src/main/java/com/klikli_dev/modonomicon/multiblock/SparseMultiblock.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/multiblock/SparseMultiblock.java
@@ -17,6 +17,7 @@ import com.klikli_dev.modonomicon.api.multiblock.StateMatcher;
 import com.klikli_dev.modonomicon.data.LoaderRegistry;
 import com.klikli_dev.modonomicon.multiblock.matcher.Matchers;
 import com.mojang.datafixers.util.Pair;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.network.FriendlyByteBuf;
@@ -65,7 +66,7 @@ public class SparseMultiblock extends AbstractMultiblock {
 
         var jsonPattern = GsonHelper.getAsJsonObject(json, "pattern");
 
-        Map<BlockPos, StateMatcher> stateMatchers = new HashMap<>();
+        Map<BlockPos, StateMatcher> stateMatchers = new Object2ObjectOpenHashMap<>();
         for (Entry<String, JsonElement> entry : jsonPattern.entrySet()) {
             if (entry.getKey().length() != 1)
                 throw new JsonSyntaxException("Pattern key needs to be only 1 character");
@@ -99,7 +100,7 @@ public class SparseMultiblock extends AbstractMultiblock {
         var viewOffZ = buffer.readVarInt();
 
         var size = buffer.readVarInt();
-        var stateMatchers = new HashMap<BlockPos, StateMatcher>();
+        var stateMatchers = new Object2ObjectOpenHashMap<BlockPos, StateMatcher>();
         for (int i = 0; i < size; i++) {
             var pos = buffer.readBlockPos();
             var type = buffer.readResourceLocation();

--- a/common/src/main/java/com/klikli_dev/modonomicon/multiblock/matcher/BlockStatePropertyMatcher.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/multiblock/matcher/BlockStatePropertyMatcher.java
@@ -13,6 +13,7 @@ import com.klikli_dev.modonomicon.api.multiblock.StateMatcher;
 import com.klikli_dev.modonomicon.api.multiblock.TriPredicate;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.commands.arguments.blocks.BlockStateParser;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -24,7 +25,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -85,7 +85,7 @@ public class BlockStatePropertyMatcher implements StateMatcher {
     }
 
     private static Map<String, String> convertProps(Map<Property<?>, Comparable<?>> props) {
-        Map<String, String> newProps = new HashMap<>();
+        Map<String, String> newProps = new Object2ObjectOpenHashMap<>();
         for (var entry : props.entrySet()) {
 
             appendProperty(newProps, entry.getKey(), entry.getValue());

--- a/common/src/main/java/com/klikli_dev/modonomicon/util/Codecs.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/util/Codecs.java
@@ -8,6 +8,7 @@ package com.klikli_dev.modonomicon.util;
 
 import com.mojang.serialization.Codec;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,7 +22,7 @@ public class Codecs {
     }
 
     public static <K, V> Codec<Map<K, V>> mutableMapFromMap(Codec<Map<K, V>> mapCodec) {
-        return mapCodec.xmap(HashMap::new, HashMap::new);
+        return mapCodec.xmap(Object2ObjectOpenHashMap::new, Object2ObjectOpenHashMap::new);
     }
 
     public static <K, V> Codec<ConcurrentMap<K, V>> concurrentMap(final Codec<K> keyCodec, final Codec<V> elementCodec) {

--- a/common/src/main/java/com/klikli_dev/modonomicon/util/Codecs.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/util/Codecs.java
@@ -7,6 +7,7 @@
 package com.klikli_dev.modonomicon.util;
 
 import com.mojang.serialization.Codec;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,7 +37,7 @@ public class Codecs {
     }
 
     public static <V> Codec<Set<V>> setFromList(Codec<List<V>> listCodec) {
-        return listCodec.xmap(HashSet::new, ArrayList::new);
+        return listCodec.xmap(ObjectOpenHashSet::new, ArrayList::new);
     }
 
 }

--- a/fabric/src/main/java/com/klikli_dev/modonomicon/registry/FabricRegistrationFactory.java
+++ b/fabric/src/main/java/com/klikli_dev/modonomicon/registry/FabricRegistrationFactory.java
@@ -6,6 +6,7 @@
 
 package com.klikli_dev.modonomicon.registry;
 
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -14,7 +15,6 @@ import net.minecraft.resources.ResourceLocation;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -34,7 +34,7 @@ public class FabricRegistrationFactory implements RegistrationProvider.Factory {
         private final String modId;
         private final Registry<T> registry;
 
-        private final Set<RegistryObject<T>> entries = new HashSet<>();
+        private final Set<RegistryObject<T>> entries = new ObjectOpenHashSet<>();
         private final Set<RegistryObject<T>> entriesView = Collections.unmodifiableSet(this.entries);
 
         @SuppressWarnings({"unchecked"})

--- a/forge/src/main/java/com/klikli_dev/modonomicon/registry/ForgeRegistrationFactory.java
+++ b/forge/src/main/java/com/klikli_dev/modonomicon/registry/ForgeRegistrationFactory.java
@@ -6,6 +6,7 @@
 
 package com.klikli_dev.modonomicon.registry;
 
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -15,7 +16,6 @@ import net.minecraftforge.fml.javafmlmod.FMLModContainer;
 import net.minecraftforge.registries.DeferredRegister;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -40,7 +40,7 @@ public class ForgeRegistrationFactory implements RegistrationProvider.Factory {
         private final String modId;
         private final DeferredRegister<T> registry;
 
-        private final Set<RegistryObject<T>> entries = new HashSet<>();
+        private final Set<RegistryObject<T>> entries = new ObjectOpenHashSet<>();
         private final Set<RegistryObject<T>> entriesView = Collections.unmodifiableSet(this.entries);
 
         private Provider(String modId, DeferredRegister<T> registry) {


### PR DESCRIPTION
Fun fact:
```java
/**
 * Constructs a new, empty set; the backing {@code HashMap} instance has
 * default initial capacity (16) and load factor (0.75).
 */
public HashSet() {
    map = new HashMap<>();
}
```
Java's HashSet actually uses an entire Hash _Map_ to store its elements.  It takes up over four times the space, and it's just... really awful. FastUtil's are significantly faster while using a quarter of the size.  I used to use them all the time, but now it just makes me feel itchy whenever I see them used.

HashMaps on the other hand are _also_ really unoptimized, using chaining (linked lists on the end of every value) to handle hash collisions instead of linear probing (finding a new spot for the next element to go into).  This adds a lot of bloat, requiring Entry objects for every value, and is also significantly slower.  It's not significant in terms of Big O - remaining in O(1) - but it's still an improvement.  For such a foundational mod, every little bit helps.

Either way FastUtil is a completely drop-in replacement for standard Java collections, so it shouldn't cause any problems.  I did avoid messing with any concurrent collections though, as FastUtil doesn't have a good answer for that currently.

