### PR TITLE
Fix GUIs not rendering after viewing book entry

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/BookGuiManager.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/BookGuiManager.java
@@ -43,7 +43,6 @@ import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -482,6 +481,7 @@ public class BookGuiManager {
     }
 
     public void closeParentScreen(BookParentScreen screen) {
+        ClientServices.GUI.popGuiLayer();
         Minecraft.getInstance().setScreen(null);
         this.openBookParentScreen = null;
 


### PR DESCRIPTION
On Fabric, after opening a Modonomicon book and viewing a book entry, then exiting the GUI via pushing the Escape key, if you exit the world and try to navigate to the Singleplayer screen for example, the GUI would not be rendering, due to the Fabric multi-layer screen still consisting of the root Modonomicon book layer.

This PR pops the root book layer when the screen is exited.