### PR TITLE
feat: add unread indicator for new/unvisited categories

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/bookstate/BookUnlockStateManager.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/bookstate/BookUnlockStateManager.java
@@ -104,6 +104,10 @@ public class BookUnlockStateManager {
         return this.getStateFor(player).isRead(entry);
     }
 
+    public boolean isCategoryReadFor(Player player, BookCategory category) {
+        return this.getStateFor(player).isCategoryRead(category);
+    }
+
     public boolean canRunFor(Player player, BookCommand command) {
         return this.getStateFor(player).canRun(command);
     }
@@ -122,6 +126,13 @@ public class BookUnlockStateManager {
      */
     public boolean readFor(ServerPlayer player, BookEntry entry) {
         return this.getStateFor(player).read(entry, player);
+    }
+
+    /**
+     * Modifies state, but does not call syncFor, needs to be done by the caller side if needed.
+     */
+    public boolean readCategoryFor(ServerPlayer player, BookCategory category) {
+        return this.getStateFor(player).readCategory(category);
     }
 
     public void onAdvancement(ServerPlayer player) {

--- a/common/src/main/java/com/klikli_dev/modonomicon/bookstate/BookUnlockStates.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/bookstate/BookUnlockStates.java
@@ -42,7 +42,8 @@ public class BookUnlockStates {
             Codec.unboundedMap(Identifier.CODEC, Codec.unboundedMap(Identifier.CODEC, Codecs.set(Codec.INT))).fieldOf("unlockedPages").forGetter((s) -> s.unlockedPages),
             Codec.unboundedMap(Identifier.CODEC, Codecs.set(Identifier.CODEC)).fieldOf("unlockedEntries").forGetter((s) -> s.unlockedEntries),
             Codec.unboundedMap(Identifier.CODEC, Codecs.set(Identifier.CODEC)).fieldOf("unlockedCategories").forGetter((s) -> s.unlockedCategories),
-            Codec.unboundedMap(Identifier.CODEC, Codec.unboundedMap(Identifier.CODEC, Codec.INT)).fieldOf("usedCommands").forGetter((s) -> s.usedCommands)
+            Codec.unboundedMap(Identifier.CODEC, Codec.unboundedMap(Identifier.CODEC, Codec.INT)).fieldOf("usedCommands").forGetter((s) -> s.usedCommands),
+            Codec.unboundedMap(Identifier.CODEC, Codecs.set(Identifier.CODEC)).optionalFieldOf("readCategories", Object2ObjectMaps.emptyMap()).forGetter((s) -> s.readCategories)
     ).apply(instance, BookUnlockStates::new));
 
     public static final StreamCodec<RegistryFriendlyByteBuf, BookUnlockStates> STREAM_CODEC = ByteBufCodecs.fromCodecWithRegistries(CODEC);
@@ -73,15 +74,21 @@ public class BookUnlockStates {
      */
     public Map<Identifier, Map<Identifier, Integer>> usedCommands;
 
+    /**
+     * Map Book ID to read category IDs
+     */
+    public Map<Identifier, Set<Identifier>> readCategories;
+
     public BookUnlockStates() {
-        this(Object2ObjectMaps.emptyMap(), Object2ObjectMaps.emptyMap(), Object2ObjectMaps.emptyMap(), Object2ObjectMaps.emptyMap(), Object2ObjectMaps.emptyMap());
+        this(Object2ObjectMaps.emptyMap(), Object2ObjectMaps.emptyMap(), Object2ObjectMaps.emptyMap(), Object2ObjectMaps.emptyMap(), Object2ObjectMaps.emptyMap(), Object2ObjectMaps.emptyMap());
     }
 
     public BookUnlockStates(Map<Identifier, Set<Identifier>> readEntries,
                             Map<Identifier, Map<Identifier, Set<Integer>>> unlockedPages,
                             Map<Identifier, Set<Identifier>> unlockedEntries,
                             Map<Identifier, Set<Identifier>> unlockedCategories,
-                            Map<Identifier, Map<Identifier, Integer>> usedCommands) {
+                            Map<Identifier, Map<Identifier, Integer>> usedCommands,
+                            Map<Identifier, Set<Identifier>> readCategories) {
         this.readEntries = Object2ObjectMaps.synchronize(new Object2ObjectOpenHashMap<>(readEntries));
 
         this.unlockedPages = Object2ObjectMaps.synchronize(new Object2ObjectOpenHashMap<>());
@@ -101,6 +108,8 @@ public class BookUnlockStates {
             var innerMap = this.usedCommands.computeIfAbsent(bookId, k -> Object2ObjectMaps.synchronize(new Object2ObjectOpenHashMap<>()));
             innerMap.putAll(commandUsesMap);
         });
+
+        this.readCategories = Object2ObjectMaps.synchronize(new Object2ObjectOpenHashMap<>(readCategories));
     }
 
     public void update(ServerPlayer owner) {
@@ -239,6 +248,24 @@ public class BookUnlockStates {
         return true;
     }
 
+    /**
+     * @return true if category is now read, false if it was already read before.
+     */
+    public boolean readCategory(BookCategory category) {
+        if (this.isCategoryRead(category))
+            return false;
+
+        this.readCategories.computeIfAbsent(category.getBook().getId(), k -> new ObjectOpenHashSet<>()).add(category.getId());
+
+        return true;
+    }
+
+    public boolean isCategoryRead(BookCategory category) {
+        if (category.getBook() == null)
+            return false;
+        return this.readCategories.getOrDefault(category.getBook().getId(), new ObjectOpenHashSet<>()).contains(category.getId());
+    }
+
     public void setRun(BookCommand command) {
         if (command.getBook() == null)
             return;
@@ -294,6 +321,7 @@ public class BookUnlockStates {
         this.unlockedPages.remove(book.getId());
         this.unlockedEntries.remove(book.getId());
         this.unlockedCategories.remove(book.getId());
+        this.readCategories.remove(book.getId());
         //Do not reset the commands!
     }
 
@@ -303,6 +331,7 @@ public class BookUnlockStates {
         books.addAll(this.unlockedPages.keySet());
         books.addAll(this.unlockedEntries.keySet());
         books.addAll(this.unlockedCategories.keySet());
+        books.addAll(this.readCategories.keySet());
         return books.stream().toList();
     }
 
@@ -330,6 +359,10 @@ public class BookUnlockStates {
         buf.writeVarInt(readEntries.size());
         readEntries.forEach(buf::writeIdentifier);
 
+        var readCategories = this.readCategories.getOrDefault(book.getId(), Set.of());
+        buf.writeVarInt(readCategories.size());
+        readCategories.forEach(buf::writeIdentifier);
+
         byte[] bytes = new byte[buf.readableBytes()];
         buf.readBytes(bytes);
 
@@ -350,6 +383,7 @@ public class BookUnlockStates {
             var unlockedEntries = new ObjectOpenHashSet<Identifier>();
             var unlockedPages = new Object2ObjectOpenHashMap<Identifier, Set<Integer>>();
             var readEntries = new ObjectOpenHashSet<Identifier>();
+            var readCategories = new ObjectOpenHashSet<Identifier>();
 
             var unlockedCategoriesSize = buf.readVarInt();
             for (var i = 0; i < unlockedCategoriesSize; i++) {
@@ -378,15 +412,25 @@ public class BookUnlockStates {
                 readEntries.add(buf.readIdentifier());
             }
 
+            // Read categories - added later, so may not be present in older unlock codes
+            if (buf.isReadable()) {
+                var readCategoriesSize = buf.readVarInt();
+                for (var i = 0; i < readCategoriesSize; i++) {
+                    readCategories.add(buf.readIdentifier());
+                }
+            }
+
             unlockedCategories.trim();
             unlockedPages.trim();
             unlockedPages.trim();
             readEntries.trim();
+            readCategories.trim();
 
             this.unlockedCategories.put(bookId, unlockedCategories);
             this.unlockedEntries.put(bookId, unlockedEntries);
             this.unlockedPages.put(bookId, unlockedPages);
             this.readEntries.put(bookId, readEntries);
+            this.readCategories.put(bookId, readCategories);
 
             return book;
         } catch (Exception e) {

--- a/common/src/main/java/com/klikli_dev/modonomicon/bookstate/BookUnlockStates.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/bookstate/BookUnlockStates.java
@@ -263,7 +263,7 @@ public class BookUnlockStates {
     public boolean isCategoryRead(BookCategory category) {
         if (category.getBook() == null)
             return false;
-        return this.readCategories.getOrDefault(category.getBook().getId(), new ObjectOpenHashSet<>()).contains(category.getId());
+        return this.readCategories.getOrDefault(category.getBook().getId(), Set.of()).contains(category.getId());
     }
 
     public void setRun(BookCommand command) {
@@ -421,7 +421,6 @@ public class BookUnlockStates {
             }
 
             unlockedCategories.trim();
-            unlockedPages.trim();
             unlockedPages.trim();
             readEntries.trim();
             readCategories.trim();

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/BookGuiManager.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/BookGuiManager.java
@@ -227,6 +227,11 @@ public class BookGuiManager {
             BookGuiManager.get().closeCategoryScreen(this.openBookCategoryScreen);
         }
 
+        //Mark category as read if not already read
+        if (!BookUnlockStateManager.get().isCategoryReadFor(this.player(), category)) {
+            Services.NETWORK.sendToServer(new BookCategoryReadMessage(category.getBook().getId(), category.getId()));
+        }
+
         var displayMode = category.getDisplayMode();
         //if the book is in index mode, force all categories into index mode too!
         if (displayMode == BookDisplayMode.INDEX || category.getBook().getDisplayMode() == BookDisplayMode.INDEX) {

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookContentRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/BookContentRenderer.java
@@ -48,6 +48,16 @@ public class BookContentRenderer {
         drawFromContentTexture(RenderPipelines.GUI_TEXTURED, guiGraphics, book, x, y, 496, 0, 16, 16, color);
     }
 
+    public static void drawUnreadIndicator(GuiGraphicsExtractor guiGraphics, Book book, int x, int y, boolean hovered) {
+        final int U = 350;
+        final int V = 19;
+        final int SIZE = 11;
+
+        guiGraphics.pose().pushMatrix();
+        drawFromContentTexture(RenderPipelines.GUI_TEXTURED, guiGraphics, book, x, y, U + (hovered ? SIZE : 0), V, SIZE, SIZE);
+        guiGraphics.pose().popMatrix();
+    }
+
     public static void playTurnPageSound(Book book) {
         if (ClientTicks.ticks - lastTurnPageSoundTime > 6) {
             var sound = BuiltInRegistries.SOUND_EVENT.getValue(book.getTurnPageSound());

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/CategoryButton.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/CategoryButton.java
@@ -91,17 +91,8 @@ public class CategoryButton extends Button {
 
             //render unread category indicator
             if (!BookUnlockStateManager.get().isCategoryReadFor(Minecraft.getInstance().player, this.category)) {
-                final int U = 350;
-                final int V = 19;
-                final int indicatorWidth = 11;
-                final int indicatorHeight = 11;
-
-                guiGraphics.pose().pushMatrix();
-                BookContentRenderer.drawFromContentTexture(RenderPipelines.GUI_TEXTURED, guiGraphics, this.category.getBook(),
-                        renderX + renderWidth - indicatorWidth + 2,
-                        this.getY() - 2,
-                        U + (this.isHovered() ? indicatorWidth : 0), V, indicatorWidth, indicatorHeight);
-                guiGraphics.pose().popMatrix();
+                BookContentRenderer.drawUnreadIndicator(guiGraphics, this.category.getBook(),
+                        renderX + renderWidth - 11 + 2, this.getY() - 2, this.isHovered());
             }
 
             guiGraphics.pose().popMatrix();

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/CategoryButton.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/CategoryButton.java
@@ -7,9 +7,12 @@
 package com.klikli_dev.modonomicon.client.gui.book.button;
 
 import com.klikli_dev.modonomicon.book.BookCategory;
+import com.klikli_dev.modonomicon.bookstate.BookUnlockStateManager;
 import com.klikli_dev.modonomicon.client.gui.BookGuiManager;
+import com.klikli_dev.modonomicon.client.gui.book.BookContentRenderer;
 import com.klikli_dev.modonomicon.client.gui.book.node.BookParentNodeScreen;
 import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Tooltip;
@@ -85,6 +88,22 @@ public class CategoryButton extends Button {
 
             guiGraphics.pose().popMatrix();
             guiGraphics.pose().popMatrix();
+
+            //render unread category indicator
+            if (!BookUnlockStateManager.get().isCategoryReadFor(Minecraft.getInstance().player, this.category)) {
+                final int U = 350;
+                final int V = 19;
+                final int indicatorWidth = 11;
+                final int indicatorHeight = 11;
+
+                guiGraphics.pose().pushMatrix();
+                BookContentRenderer.drawFromContentTexture(RenderPipelines.GUI_TEXTURED, guiGraphics, this.category.getBook(),
+                        renderX + renderWidth - indicatorWidth + 2,
+                        this.getY() - 2,
+                        U + (this.isHovered() ? indicatorWidth : 0), V, indicatorWidth, indicatorHeight);
+                guiGraphics.pose().popMatrix();
+            }
+
             guiGraphics.pose().popMatrix();
         }
     }

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/CategoryListButton.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/CategoryListButton.java
@@ -19,7 +19,6 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.sounds.SoundManager;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FontDescription;
@@ -101,17 +100,10 @@ public class CategoryListButton extends Button {
 
             //render unread category indicator
             if (!locked && !BookUnlockStateManager.get().isCategoryReadFor(Minecraft.getInstance().player, this.category)) {
-                final int U = 350;
-                final int V = 19;
-                final int indicatorWidth = 11;
-                final int indicatorHeight = 11;
-
                 guiGraphics.pose().pushMatrix();
                 guiGraphics.pose().scale(0.5F, 0.5F);
-                BookContentRenderer.drawFromContentTexture(RenderPipelines.GUI_TEXTURED, guiGraphics, this.category.getBook(),
-                        this.getX() * 2 + BookEntryScreen.PAGE_WIDTH * 2 - indicatorWidth - 2,
-                        this.getY() * 2 + 2,
-                        U + (this.isHovered() ? indicatorWidth : 0), V, indicatorWidth, indicatorHeight);
+                BookContentRenderer.drawUnreadIndicator(guiGraphics, this.category.getBook(),
+                        this.getX() * 2 + BookEntryScreen.PAGE_WIDTH * 2 - 11 - 2, this.getY() * 2 + 2, this.isHovered());
                 guiGraphics.pose().scale(2F, 2F);
                 guiGraphics.pose().popMatrix();
             }

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/CategoryListButton.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/CategoryListButton.java
@@ -19,6 +19,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.sounds.SoundManager;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FontDescription;
@@ -97,6 +98,23 @@ public class CategoryListButton extends Button {
             guiGraphics.text(Minecraft.getInstance().font, name, x, y, this.getEntryColor(), false);
 
             guiGraphics.pose().popMatrix();
+
+            //render unread category indicator
+            if (!locked && !BookUnlockStateManager.get().isCategoryReadFor(Minecraft.getInstance().player, this.category)) {
+                final int U = 350;
+                final int V = 19;
+                final int indicatorWidth = 11;
+                final int indicatorHeight = 11;
+
+                guiGraphics.pose().pushMatrix();
+                guiGraphics.pose().scale(0.5F, 0.5F);
+                BookContentRenderer.drawFromContentTexture(RenderPipelines.GUI_TEXTURED, guiGraphics, this.category.getBook(),
+                        this.getX() * 2 + BookEntryScreen.PAGE_WIDTH * 2 - indicatorWidth - 2,
+                        this.getY() * 2 + 2,
+                        U + (this.isHovered() ? indicatorWidth : 0), V, indicatorWidth, indicatorHeight);
+                guiGraphics.pose().scale(2F, 2F);
+                guiGraphics.pose().popMatrix();
+            }
         }
     }
 

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/index/BookParentIndexScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/index/BookParentIndexScreen.java
@@ -66,6 +66,8 @@ public class BookParentIndexScreen extends BookPaginatedScreen implements BookPa
 
     private boolean hasUnreadEntries;
     private boolean hasUnreadUnlockedEntries;
+    private boolean hasUnreadCategories;
+    private boolean hasUnreadUnlockedCategories;
 
     public BookParentIndexScreen(Book book) {
         super(Component.translatable(book.getName()));
@@ -81,6 +83,12 @@ public class BookParentIndexScreen extends BookPaginatedScreen implements BookPa
         this.hasUnreadUnlockedEntries = this.book.getEntries().values().stream().anyMatch(e ->
                 BookUnlockStateManager.get().isUnlockedFor(this.minecraft.player, e) &&
                         !BookUnlockStateManager.get().isReadFor(this.minecraft.player, e));
+
+        //check if ANY category is unread
+        this.hasUnreadCategories = this.book.getCategories().values().stream().anyMatch(c -> !BookUnlockStateManager.get().isCategoryReadFor(this.minecraft.player, c));
+
+        //check if any currently unlocked category is unread
+        this.hasUnreadUnlockedCategories = this.book.getCategories().values().stream().anyMatch(c -> BookUnlockStateManager.get().isUnlockedFor(this.minecraft.player, c) && !BookUnlockStateManager.get().isCategoryReadFor(this.minecraft.player, c));
     }
 
     public void handleButtonEntry(Button button) {
@@ -309,7 +317,7 @@ public class BookParentIndexScreen extends BookPaginatedScreen implements BookPa
     }
 
     protected boolean canSeeReadAllButton() {
-        return this.hasUnreadEntries || this.hasUnreadUnlockedEntries;
+        return this.hasUnreadEntries || this.hasUnreadUnlockedEntries || this.hasUnreadCategories || this.hasUnreadUnlockedCategories;
     }
 
 

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/node/BookCategoryNodeScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/node/BookCategoryNodeScreen.java
@@ -252,18 +252,9 @@ public class BookCategoryNodeScreen implements BookCategoryScreen {
 
             //render unread icon
             if (displayState == EntryDisplayState.UNLOCKED && !BookUnlockStateManager.get().isReadFor(Minecraft.getInstance().player, entry)) {
-                final int U = 350;
-                final int V = 19;
-                final int width = 11;
-                final int height = 11;
-
-                guiGraphics.pose().pushMatrix();
-                //TODO here we had translate +11 z
-                //if focused we go to the right of our normal button (instead of down, like mc buttons do)
-                BookContentRenderer.drawFromContentTexture(RenderPipelines.GUI_TEXTURED, guiGraphics, this.bookParentScreen.getBook(),
+                BookContentRenderer.drawUnreadIndicator(guiGraphics, this.bookParentScreen.getBook(),
                         entry.getX() * ENTRY_GRID_SCALE + ENTRY_GAP + 16 + 2,
-                        entry.getY() * ENTRY_GRID_SCALE + ENTRY_GAP - 2, U + (isHovered ? width : 0), V, width, height);
-                guiGraphics.pose().popMatrix();
+                        entry.getY() * ENTRY_GRID_SCALE + ENTRY_GAP - 2, isHovered);
             }
 
             guiGraphics.pose().popMatrix();

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/node/BookParentNodeScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/node/BookParentNodeScreen.java
@@ -53,6 +53,8 @@ public class BookParentNodeScreen extends Screen implements BookParentScreen, Bo
     private BookCategoryNodeScreen currentCategoryNodeScreen;
     private boolean hasUnreadEntries;
     private boolean hasUnreadUnlockedEntries;
+    private boolean hasUnreadCategories;
+    private boolean hasUnreadUnlockedCategories;
 
     private int categoryButtonRenderOffset = 0;
 
@@ -79,6 +81,12 @@ public class BookParentNodeScreen extends Screen implements BookParentScreen, Bo
 
         //check if any currently unlocked entry is unread
         this.hasUnreadUnlockedEntries = this.book.getEntries().values().stream().anyMatch(e -> BookUnlockStateManager.get().isUnlockedFor(this.minecraft.player, e) && !BookUnlockStateManager.get().isReadFor(this.minecraft.player, e));
+
+        //check if ANY category is unread
+        this.hasUnreadCategories = this.book.getCategories().values().stream().anyMatch(c -> !BookUnlockStateManager.get().isCategoryReadFor(this.minecraft.player, c));
+
+        //check if any currently unlocked category is unread
+        this.hasUnreadUnlockedCategories = this.book.getCategories().values().stream().anyMatch(c -> BookUnlockStateManager.get().isUnlockedFor(this.minecraft.player, c) && !BookUnlockStateManager.get().isCategoryReadFor(this.minecraft.player, c));
     }
 
     public BookCategoryNodeScreen getCurrentCategoryScreen() {
@@ -195,7 +203,7 @@ public class BookParentNodeScreen extends Screen implements BookParentScreen, Bo
     }
 
     protected boolean canSeeReadAllButton() {
-        return this.hasUnreadEntries || this.hasUnreadUnlockedEntries;
+        return this.hasUnreadEntries || this.hasUnreadUnlockedEntries || this.hasUnreadCategories || this.hasUnreadUnlockedCategories;
     }
 
     @Override

--- a/common/src/main/java/com/klikli_dev/modonomicon/networking/BookCategoryReadMessage.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/networking/BookCategoryReadMessage.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2024 klikli-dev
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.klikli_dev.modonomicon.networking;
+
+import com.klikli_dev.modonomicon.Modonomicon;
+import com.klikli_dev.modonomicon.bookstate.BookUnlockStateManager;
+import com.klikli_dev.modonomicon.data.BookDataManager;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+
+public class BookCategoryReadMessage implements Message {
+
+    public static final Type<BookCategoryReadMessage> TYPE = new Type<>(Identifier.fromNamespaceAndPath(Modonomicon.MOD_ID, "book_category_read"));
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, BookCategoryReadMessage> STREAM_CODEC = StreamCodec.composite(
+            Identifier.STREAM_CODEC,
+            (m) -> m.bookId,
+            Identifier.STREAM_CODEC,
+            (m) -> m.categoryId,
+            BookCategoryReadMessage::new
+    );
+
+    public Identifier bookId;
+    public Identifier categoryId;
+
+    public BookCategoryReadMessage(Identifier bookId, Identifier categoryId) {
+        this.bookId = bookId;
+        this.categoryId = categoryId;
+    }
+
+    @Override
+    public CustomPacketPayload.Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    @Override
+    public void onServerReceived(MinecraftServer minecraftServer, ServerPlayer player) {
+        var book = BookDataManager.get().getBook(this.bookId);
+        if (book != null) {
+            var category = book.getCategory(this.categoryId);
+            if (category != null && BookUnlockStateManager.get().readCategoryFor(player, category)) {
+                BookUnlockStateManager.get().updateAndSyncFor(player);
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/klikli_dev/modonomicon/networking/ClickReadAllButtonMessage.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/networking/ClickReadAllButtonMessage.java
@@ -49,6 +49,12 @@ public class ClickReadAllButtonMessage implements Message {
                 }
             }
 
+            for (var category : book.getCategories().values()) {
+                if ((this.readAll || BookUnlockStateManager.get().isUnlockedFor(player, category)) && BookUnlockStateManager.get().readCategoryFor(player, category)) {
+                    anyRead = true;
+                }
+            }
+
             if (anyRead) {
                 BookUnlockStateManager.get().updateAndSyncFor(player);
             }

--- a/fabric/src/main/java/com/klikli_dev/modonomicon/network/Networking.java
+++ b/fabric/src/main/java/com/klikli_dev/modonomicon/network/Networking.java
@@ -14,6 +14,7 @@ public class Networking {
 
     public static void registerReceivers() {
         ServerPlayNetworking.registerGlobalReceiver(BookEntryReadMessage.TYPE, new ServerMessageHandler<>());
+        ServerPlayNetworking.registerGlobalReceiver(BookCategoryReadMessage.TYPE, new ServerMessageHandler<>());
         ServerPlayNetworking.registerGlobalReceiver(ClickCommandLinkMessage.TYPE, new ServerMessageHandler<>());
         ServerPlayNetworking.registerGlobalReceiver(ClickReadAllButtonMessage.TYPE, new ServerMessageHandler<>());
         ServerPlayNetworking.registerGlobalReceiver(SaveBookStateMessage.TYPE, new ServerMessageHandler<>());
@@ -30,6 +31,7 @@ public class Networking {
     public static void registerMessages() {
         //to server
         PayloadTypeRegistry.serverboundPlay().register(BookEntryReadMessage.TYPE, BookEntryReadMessage.STREAM_CODEC);
+        PayloadTypeRegistry.serverboundPlay().register(BookCategoryReadMessage.TYPE, BookCategoryReadMessage.STREAM_CODEC);
         PayloadTypeRegistry.serverboundPlay().register(ClickCommandLinkMessage.TYPE, ClickCommandLinkMessage.STREAM_CODEC);
         PayloadTypeRegistry.serverboundPlay().register(ClickReadAllButtonMessage.TYPE, ClickReadAllButtonMessage.STREAM_CODEC);
         PayloadTypeRegistry.serverboundPlay().register(SaveBookStateMessage.TYPE, SaveBookStateMessage.STREAM_CODEC);

--- a/forge/src/main/java/com/klikli_dev/modonomicon/network/Networking.java
+++ b/forge/src/main/java/com/klikli_dev/modonomicon/network/Networking.java
@@ -68,6 +68,12 @@ public class Networking {
                 .consumerNetworkThread((BiConsumer<BookEntryReadMessage, CustomPayloadEvent.Context>) MessageHandler::handle)
                 .add();
 
+        INSTANCE.messageBuilder(BookCategoryReadMessage.class)
+                .encoder(encoder(BookCategoryReadMessage.STREAM_CODEC))
+                .decoder(decoder(BookCategoryReadMessage.STREAM_CODEC))
+                .consumerNetworkThread((BiConsumer<BookCategoryReadMessage, CustomPayloadEvent.Context>) MessageHandler::handle)
+                .add();
+
         INSTANCE.messageBuilder(ClickCommandLinkMessage.class)
                 .encoder(encoder(ClickCommandLinkMessage.STREAM_CODEC))
                 .decoder(decoder(ClickCommandLinkMessage.STREAM_CODEC))

--- a/neo/src/main/java/com/klikli_dev/modonomicon/network/Networking.java
+++ b/neo/src/main/java/com/klikli_dev/modonomicon/network/Networking.java
@@ -19,6 +19,7 @@ public class Networking {
         var registrar = event.registrar(Modonomicon.MOD_ID);
 
         registrar.playToServer(BookEntryReadMessage.TYPE, BookEntryReadMessage.STREAM_CODEC, MessageHandler::handle);
+        registrar.playToServer(BookCategoryReadMessage.TYPE, BookCategoryReadMessage.STREAM_CODEC, MessageHandler::handle);
         registrar.playToServer(ClickCommandLinkMessage.TYPE, ClickCommandLinkMessage.STREAM_CODEC, MessageHandler::handle);
         registrar.playToServer(ClickReadAllButtonMessage.TYPE, ClickReadAllButtonMessage.STREAM_CODEC, MessageHandler::handle);
         registrar.playToServer(SaveBookStateMessage.TYPE, SaveBookStateMessage.STREAM_CODEC, MessageHandler::handle);


### PR DESCRIPTION
## Summary

Implements #315 — adds an unread indicator (matching the existing entry unread indicator) to category buttons that the player has never opened.

## Changes

- **State tracking**: Added `readCategories` field to `BookUnlockStates` with codec persistence (`optionalFieldOf` for backward compatibility). Added `readCategory()`/`isCategoryRead()` methods and corresponding `BookUnlockStateManager` methods.
- **Network message**: Created `BookCategoryReadMessage` (modeled after `BookEntryReadMessage`), registered on all 3 platforms (Fabric, NeoForge, Forge). Sent from `BookGuiManager.openCategory()` when opening an unread category.
- **Unread indicator rendering**: Added the 11×11 unread indicator icon to both `CategoryButton` (node-mode sidebar) and `CategoryListButton` (index-mode list), using the same sprite from the book content texture as the entry unread indicator.
- **Read All button**: Updated `ClickReadAllButtonMessage` to also mark categories as read. Updated `updateUnreadEntriesState()` and `canSeeReadAllButton()` in both `BookParentNodeScreen` and `BookParentIndexScreen` so the read-all button also appears when there are unread categories.
- **Unlock code import/export**: Updated to include `readCategories`, with backward-compatible reading for older codes.

Closes #315


<img width="280" height="327" alt="image" src="https://github.com/user-attachments/assets/ac1da2d1-630d-408c-b314-0aa4efe27fe4" />
