### PR TITLE
fix: use GhostRenderState for multiblock preview tessellation

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/api/multiblock/Multiblock.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/api/multiblock/Multiblock.java
@@ -7,11 +7,11 @@
 package com.klikli_dev.modonomicon.api.multiblock;
 
 import com.mojang.datafixers.util.Pair;
-import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.BlockAndLightGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Rotation;
 import org.jetbrains.annotations.Nullable;
@@ -27,7 +27,7 @@ import java.util.Collection;
  * do not create your own implementation of this, as it'll not be compatible with
  * all the features in the mod.
  */
-public interface Multiblock extends BlockAndTintGetter {
+public interface Multiblock extends BlockAndLightGetter {
 
     // ================================================================================================
     // Builder methods

--- a/common/src/main/java/com/klikli_dev/modonomicon/api/stub/multiblock/StubMultiblock.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/api/stub/multiblock/StubMultiblock.java
@@ -9,18 +9,17 @@ import com.klikli_dev.modonomicon.api.ModonomiconAPI;
 import com.klikli_dev.modonomicon.api.multiblock.Multiblock;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.level.CardinalLighting;
-import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.lighting.LevelLightEngine;
 import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -122,17 +121,7 @@ public class StubMultiblock implements Multiblock {
 
     @Override
     public LevelLightEngine getLightEngine() {
-        return null;
-    }
-
-    @Override
-    public CardinalLighting cardinalLighting() {
-        return CardinalLighting.DEFAULT;
-    }
-
-    @Override
-    public int getBlockTint(BlockPos blockPos, ColorResolver colorResolver) {
-        return 0;
+        return LevelLightEngine.EMPTY;
     }
 
     @Nullable
@@ -143,12 +132,12 @@ public class StubMultiblock implements Multiblock {
 
     @Override
     public BlockState getBlockState(BlockPos pos) {
-        return null;
+        return Blocks.AIR.defaultBlockState();
     }
 
     @Override
     public FluidState getFluidState(BlockPos pos) {
-        return null;
+        return Fluids.EMPTY.defaultFluidState();
     }
 
     @Override

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/MultiblockPreviewRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/MultiblockPreviewRenderer.java
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2022 Authors of Patchouli
  * SPDX-FileCopyrightText: 2022 klikli-dev
+ * SPDX-FileCopyrightText: 2026 XFactHD
  *
  * SPDX-License-Identifier: MIT
  */
@@ -12,6 +13,7 @@ import com.klikli_dev.modonomicon.api.ModonomiconConstants;
 import com.klikli_dev.modonomicon.api.multiblock.Multiblock;
 import com.klikli_dev.modonomicon.api.multiblock.MultiblockPreviewData;
 import com.klikli_dev.modonomicon.client.ClientTicks;
+import com.klikli_dev.modonomicon.client.render.fakelevel.GhostRenderState;
 import com.klikli_dev.modonomicon.multiblock.AbstractMultiblock;
 import com.klikli_dev.modonomicon.multiblock.matcher.DisplayOnlyMatcher;
 import com.klikli_dev.modonomicon.multiblock.matcher.Matchers;
@@ -26,8 +28,8 @@ import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.vertex.*;
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderPipelines;
@@ -35,7 +37,6 @@ import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.block.BlockQuadOutput;
 import net.minecraft.client.renderer.block.ModelBlockRenderer;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
-import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
@@ -50,7 +51,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Mth;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
@@ -83,8 +83,6 @@ public class MultiblockPreviewRenderer {
     private static final Map<BlockPos, BlockEntity> blockEntityCache = new Object2ObjectOpenHashMap<>();
     private static final Set<BlockEntity> erroredBlockEntities = Collections.newSetFromMap(new WeakHashMap<>());
     private static final List<BlockEntityRenderState> blockEntityRenderStates = new ArrayList<>();
-    private static final RandomSource RANDOM = RandomSource.create();
-    private static final ObjectArrayList<BlockStateModelPart> PART_SCRATCH_LIST = new ObjectArrayList<>();
     private static final ByteBufferBuilder BUFFER_BUILDER = new ByteBufferBuilder(RenderType.TRANSIENT_BUFFER_SIZE);
 
     private static final Map<RenderType, RenderType> GHOST_RENDER_TYPE_CACHE = new java.util.IdentityHashMap<>();
@@ -409,7 +407,7 @@ public class MultiblockPreviewRenderer {
 
                 if (!r.test(level, facingRotation)) {
                     BlockState displayedState = r.stateMatcher().getDisplayedState(ClientTicks.ticks).rotate(facingRotation);
-                    renderBlock(level, displayedState, r.worldPosition(), multiblock, air, alpha, blockRenderer, ms, buffer);
+                    renderBlock(level, displayedState, r.worldPosition(), alpha, blockRenderer, ms, buffer);
 
                     if (air) {
                         airFilled++;
@@ -482,10 +480,13 @@ public class MultiblockPreviewRenderer {
         }
     }
 
-    public static void renderBlock(Level world, BlockState state, BlockPos pos, Multiblock multiblock, boolean isAir, float alpha, ModelBlockRenderer blockRenderer, PoseStack poseStack, BufferBuilder buffer) {
+    public static void renderBlock(Level world, BlockState state, BlockPos pos, float alpha, ModelBlockRenderer blockRenderer, PoseStack poseStack, BufferBuilder buffer) {
         if (pos == null) return;
 
         Minecraft mc = Minecraft.getInstance();
+        if (!(world instanceof ClientLevel clientLevel)) {
+            return;
+        }
         Vec3 cameraPos = mc.gameRenderer.getMainCamera().position();
         Vec3 offset = Vec3.atLowerCornerOf(pos).subtract(cameraPos);
 
@@ -507,9 +508,8 @@ public class MultiblockPreviewRenderer {
         poseStack.translate(-.5F, -.5F, -.5F);
 
         BlockStateModel model = mc.getModelManager().getBlockStateModelSet().get(state);
-        model.collectParts(RANDOM, PART_SCRATCH_LIST);
-        blockRenderer.tesselateBlock(output, 0, 0, 0, multiblock, pos, state, model, 0);
-        PART_SCRATCH_LIST.clear();
+        GhostRenderState renderState = new GhostRenderState(clientLevel, pos, state);
+        blockRenderer.tesselateBlock(output, 0, 0, 0, renderState, pos, state, model, 0);
 
         poseStack.popPose();
     }

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/fakelevel/BlockRenderFakeLevel.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/fakelevel/BlockRenderFakeLevel.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2026 klikli-dev
+ * SPDX-FileCopyrightText: 2026 XFactHD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.klikli_dev.modonomicon.client.render.fakelevel;
+
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LightLayer;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.lighting.LightEngine;
+import net.minecraft.world.level.material.FluidState;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Adapted from FramedBlocks' BlockRenderFakeLevel.
+ * Source: https://github.com/XFactHD/FramedBlocks/blob/26.1/src/main/java/io/github/xfacthd/framedblocks/api/render/fakelevel/BlockRenderFakeLevel.java
+ */
+public interface BlockRenderFakeLevel extends BlockAndTintGetter {
+
+    BlockPos pos();
+
+    BlockState state();
+
+    @Override
+    default BlockState getBlockState(BlockPos pos) {
+        if (pos.equals(pos())) {
+            return state();
+        }
+        return Blocks.AIR.defaultBlockState();
+    }
+
+    @Override
+    default @Nullable BlockEntity getBlockEntity(BlockPos pos) {
+        return null;
+    }
+
+    @Override
+    default FluidState getFluidState(BlockPos pos) {
+        return getBlockState(pos).getFluidState();
+    }
+
+    @Override
+    default int getBrightness(LightLayer layer, BlockPos pos) {
+        return LightEngine.MAX_LEVEL;
+    }
+
+    @Override
+    default int getRawBrightness(BlockPos pos, int ambientDarkening) {
+        return LightEngine.MAX_LEVEL - ambientDarkening;
+    }
+}

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/fakelevel/DelegatingBlockRenderFakeLevel.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/fakelevel/DelegatingBlockRenderFakeLevel.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 klikli-dev
+ * SPDX-FileCopyrightText: 2026 XFactHD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.klikli_dev.modonomicon.client.render.fakelevel;
+
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.CardinalLighting;
+import net.minecraft.world.level.ColorResolver;
+import net.minecraft.world.level.lighting.LevelLightEngine;
+
+/**
+ * Adapted from FramedBlocks' DelegatingBlockRenderFakeLevel.
+ * Source: https://github.com/XFactHD/FramedBlocks/blob/26.1/src/main/java/io/github/xfacthd/framedblocks/api/render/fakelevel/DelegatingBlockRenderFakeLevel.java
+ */
+public interface DelegatingBlockRenderFakeLevel extends BlockRenderFakeLevel {
+
+    BlockAndTintGetter realLevel();
+
+    @Override
+    default LevelLightEngine getLightEngine() {
+        return realLevel().getLightEngine();
+    }
+
+    @Override
+    default CardinalLighting cardinalLighting() {
+        return realLevel().cardinalLighting();
+    }
+
+    @Override
+    default int getBlockTint(BlockPos pos, ColorResolver resolver) {
+        if (pos.equals(pos())) {
+            return realLevel().getBlockTint(pos, resolver);
+        }
+        return -1;
+    }
+
+    @Override
+    default int getHeight() {
+        return realLevel().getHeight();
+    }
+
+    @Override
+    default int getMinY() {
+        return realLevel().getMinY();
+    }
+}

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/fakelevel/GhostRenderState.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/fakelevel/GhostRenderState.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 klikli-dev
+ * SPDX-FileCopyrightText: 2026 XFactHD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.klikli_dev.modonomicon.client.render.fakelevel;
+
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * Adapted from FramedBlocks' GhostBlockRenderer ghost render state.
+ * Source: https://github.com/XFactHD/FramedBlocks/blob/26.1/src/main/java/io/github/xfacthd/framedblocks/client/render/special/GhostBlockRenderer.java
+ */
+public record GhostRenderState(
+        ClientLevel realLevel,
+        BlockPos pos,
+        BlockState state
+) implements DelegatingBlockRenderFakeLevel { }

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/pip/GuiMultiblockRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/pip/GuiMultiblockRenderer.java
@@ -171,10 +171,10 @@ public class GuiMultiblockRenderer extends PictureInPictureRenderer<GuiMultibloc
             PoseStack.Pose pose = ps.last();
 
             var renderType = model.hasMaterialFlag(net.minecraft.client.resources.model.geometry.BakedQuad.FLAG_TRANSLUCENT) ? Sheets.translucentBlockSheet() : Sheets.cutoutBlockSheet();
+            VertexConsumer buffer = new GhostVertexConsumer(this.bufferSource.getBuffer(renderType), (int) (alpha * 255.0F));
 
             BlockQuadOutput output = (_, _, _, quad, instance) ->
             {
-                VertexConsumer buffer = new GhostVertexConsumer(this.bufferSource.getBuffer(renderType), (int) (alpha * 255.0F));
                 buffer.putBakedQuad(pose, quad, instance);
             };
             ModelBlockRenderer blockRenderer = new ModelBlockRenderer(minecraft.options.ambientOcclusion().get(), false, minecraft.getBlockColors());

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/pip/GuiMultiblockRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/pip/GuiMultiblockRenderer.java
@@ -1,8 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2026 klikli-dev
+ * SPDX-FileCopyrightText: 2026 XFactHD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 package com.klikli_dev.modonomicon.client.render.pip;
 
 import com.klikli_dev.modonomicon.Modonomicon;
 import com.klikli_dev.modonomicon.api.multiblock.Multiblock;
 import com.klikli_dev.modonomicon.client.ClientTicks;
+import com.klikli_dev.modonomicon.client.render.GhostVertexConsumer;
+import com.klikli_dev.modonomicon.client.render.fakelevel.GhostRenderState;
 import com.klikli_dev.modonomicon.client.render.state.pip.GuiMultiblockRenderState;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -106,7 +115,7 @@ public class GuiMultiblockRenderer extends PictureInPictureRenderer<GuiMultibloc
             BlockState displayedBlockState = r.stateMatcher().getDisplayedState(ClientTicks.ticks).rotate(state.facingRotation());
 
             // Render block (via platform service)
-            this.renderBlock(buffers, level, state.multiblock(), displayedBlockState, r.worldPosition(), alpha, poseStack, state.randomSource());
+            this.renderBlock(level, displayedBlockState, r.worldPosition(), alpha, poseStack);
 
             if (displayedBlockState.getBlock() instanceof EntityBlock eb) {
                 var cache = state.blockEntityCache();
@@ -152,7 +161,7 @@ public class GuiMultiblockRenderer extends PictureInPictureRenderer<GuiMultibloc
         poseStack.popPose();
     }
 
-    private void renderBlock(MultiBufferSource.BufferSource buffers, ClientLevel level, Multiblock multiblock, BlockState state, BlockPos pos, float alpha, PoseStack ps, net.minecraft.util.RandomSource randomSource) {
+    private void renderBlock(ClientLevel level, BlockState state, BlockPos pos, float alpha, PoseStack ps) {
         if (pos != null) {
             ps.pushPose();
             ps.translate(pos.getX(), pos.getY(), pos.getZ());
@@ -165,11 +174,12 @@ public class GuiMultiblockRenderer extends PictureInPictureRenderer<GuiMultibloc
 
             BlockQuadOutput output = (_, _, _, quad, instance) ->
             {
-                VertexConsumer buffer = this.bufferSource.getBuffer(renderType);
+                VertexConsumer buffer = new GhostVertexConsumer(this.bufferSource.getBuffer(renderType), (int) (alpha * 255.0F));
                 buffer.putBakedQuad(pose, quad, instance);
             };
             ModelBlockRenderer blockRenderer = new ModelBlockRenderer(minecraft.options.ambientOcclusion().get(), false, minecraft.getBlockColors());
-            blockRenderer.tesselateBlock(output, 0, 0, 0, multiblock, BlockPos.ZERO, state, model, 0);
+            GhostRenderState renderState = new GhostRenderState(level, pos, state);
+            blockRenderer.tesselateBlock(output, 0, 0, 0, renderState, pos, state, model, 0);
 
             ps.popPose();
 

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/pip/GuiMultiblockRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/pip/GuiMultiblockRenderer.java
@@ -10,7 +10,6 @@ package com.klikli_dev.modonomicon.client.render.pip;
 import com.klikli_dev.modonomicon.Modonomicon;
 import com.klikli_dev.modonomicon.api.multiblock.Multiblock;
 import com.klikli_dev.modonomicon.client.ClientTicks;
-import com.klikli_dev.modonomicon.client.render.GhostVertexConsumer;
 import com.klikli_dev.modonomicon.client.render.fakelevel.GhostRenderState;
 import com.klikli_dev.modonomicon.client.render.state.pip.GuiMultiblockRenderState;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -19,6 +18,7 @@ import com.mojang.math.Axis;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.render.pip.PictureInPictureRenderer;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.block.BlockQuadOutput;
@@ -144,7 +144,7 @@ public class GuiMultiblockRenderer extends PictureInPictureRenderer<GuiMultibloc
                             var renderState = renderer.createRenderState();
                             //Note: we cannot use Minecraft.getInstance().getBlockEntityRenderDispatcher().tryExtractRenderState because that takes the camera eye position of the in-world camera
                             renderer.extractRenderState(be, renderState, ClientTicks.partialTicks, eye3, null);
-                            renderState.lightCoords = LightCoordsUtil.FULL_BRIGHT;
+                            renderState.lightCoords = LevelRenderer.getLightCoords(level, bePos);
                             var featureDispatcher = Minecraft.getInstance().gameRenderer.getFeatureRenderDispatcher();
                             var cameraRenderState = new CameraRenderState();
                             dispatcher.submit(renderState, poseStack, featureDispatcher.getSubmitNodeStorage(), cameraRenderState);
@@ -169,12 +169,14 @@ public class GuiMultiblockRenderer extends PictureInPictureRenderer<GuiMultibloc
             Minecraft minecraft = Minecraft.getInstance();
             BlockStateModel model = minecraft.getModelManager().getBlockStateModelSet().get(state);
             PoseStack.Pose pose = ps.last();
+            int lightCoords = LevelRenderer.getLightCoords(LevelRenderer.BrightnessGetter.DEFAULT, level, state, pos);
 
             var renderType = model.hasMaterialFlag(net.minecraft.client.resources.model.geometry.BakedQuad.FLAG_TRANSLUCENT) ? Sheets.translucentBlockSheet() : Sheets.cutoutBlockSheet();
-            VertexConsumer buffer = new GhostVertexConsumer(this.bufferSource.getBuffer(renderType), (int) (alpha * 255.0F));
+            VertexConsumer buffer = this.bufferSource.getBuffer(renderType);
 
             BlockQuadOutput output = (_, _, _, quad, instance) ->
             {
+                instance.setLightCoords(lightCoords);
                 buffer.putBakedQuad(pose, quad, instance);
             };
             ModelBlockRenderer blockRenderer = new ModelBlockRenderer(minecraft.options.ambientOcclusion().get(), false, minecraft.getBlockColors());

--- a/common/src/main/java/com/klikli_dev/modonomicon/multiblock/AbstractMultiblock.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/multiblock/AbstractMultiblock.java
@@ -18,14 +18,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Vec3i;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LightLayer;
-import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -239,14 +236,7 @@ public abstract class AbstractMultiblock implements Multiblock {
 
     @Override
     public LevelLightEngine getLightEngine() {
-        return null;
-    }
-
-    @Override
-    public int getBlockTint(BlockPos pos, ColorResolver color) {
-        var plains = this.level.registryAccess().lookupOrThrow(Registries.BIOME)
-                .getValueOrThrow(Biomes.PLAINS);
-        return color.getColor(plains, pos.getX(), pos.getZ());
+        return this.level != null ? this.level.getLightEngine() : LevelLightEngine.EMPTY;
     }
 
     @Override
@@ -269,4 +259,5 @@ public abstract class AbstractMultiblock implements Multiblock {
     public int getMinY() {
         return 0;
     }
+
 }

--- a/common/src/main/java/com/klikli_dev/modonomicon/multiblock/DenseMultiblock.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/multiblock/DenseMultiblock.java
@@ -25,7 +25,6 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Rotation;
@@ -253,10 +252,5 @@ public class DenseMultiblock extends AbstractMultiblock {
         }
         long ticks = this.level != null ? this.level.getGameTime() : 0L;
         return this.stateMatchers[x][y][z].getDisplayedState(ticks);
-    }
-
-    @Override
-    public CardinalLighting cardinalLighting() {
-        return CardinalLighting.DEFAULT;
     }
 }

--- a/common/src/main/java/com/klikli_dev/modonomicon/multiblock/SparseMultiblock.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/multiblock/SparseMultiblock.java
@@ -25,7 +25,6 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.GsonHelper;
-import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
@@ -191,10 +190,5 @@ public class SparseMultiblock extends AbstractMultiblock {
     public BlockState getBlockState(BlockPos pos) {
         long ticks = this.level != null ? this.level.getGameTime() : 0L;
         return this.stateMatchers.getOrDefault(pos, Matchers.AIR).getDisplayedState(ticks);
-    }
-
-    @Override
-    public CardinalLighting cardinalLighting() {
-        return CardinalLighting.DEFAULT;
     }
 }


### PR DESCRIPTION
## Summary
- make `Multiblock` extend `BlockAndLightGetter` so multiblock data no longer acts as a client tint/render getter
- render multiblock previews through a dedicated `GhostRenderState` fake level that satisfies `ModelBlockRenderer#tesselateBlock`
- keep the FramedBlocks-inspired helper types MIT-headed with explicit attribution and link the upstream source files used

## Verification
- `./gradlew :common:compileJava :fabric:compileJava :neo:compileJava`

## Upstream sources
- `GhostBlockRenderer`: https://github.com/XFactHD/FramedBlocks/blob/26.1/src/main/java/io/github/xfacthd/framedblocks/client/render/special/GhostBlockRenderer.java
- `BlockRenderFakeLevel`: https://github.com/XFactHD/FramedBlocks/blob/26.1/src/main/java/io/github/xfacthd/framedblocks/api/render/fakelevel/BlockRenderFakeLevel.java
- `DelegatingBlockRenderFakeLevel`: https://github.com/XFactHD/FramedBlocks/blob/26.1/src/main/java/io/github/xfacthd/framedblocks/api/render/fakelevel/DelegatingBlockRenderFakeLevel.java