### PR TITLE
fix: always show entry back button

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/BookButton.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/BookButton.java
@@ -40,8 +40,8 @@ public class BookButton extends Button {
 
     @Override
     protected void extractContents(GuiGraphicsExtractor guiGraphics, int i, int j, float f) {
-        this.active = this.visible = this.displayCondition.get();
-        if (!this.visible) return;
+        this.active = this.displayCondition.get();
+        if (!this.active) return;
 
         //if focused we go to the right of our normal button (instead of down, like mc buttons do)
         BookContentRenderer.drawFromContentTexture(RenderPipelines.GUI_TEXTURED, guiGraphics, this.parent.getBook(), this.getX(), this.getY(), this.u + (this.isHovered() ? this.width : 0), this.v, this.width, this.height);

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/ReadAllButton.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/button/ReadAllButton.java
@@ -63,8 +63,8 @@ public class ReadAllButton extends Button {
 
     @Override
     protected void extractContents(GuiGraphicsExtractor guiGraphics, int i, int j, float f) {
-        this.active = this.visible = this.displayCondition.get();
-        if (!this.visible) return;
+        this.active = this.displayCondition.get();
+        if (!this.active) return;
         //if focused we go to the right of our normal button (instead of down, like mc buttons do)
 
         guiGraphics.pose().pushMatrix();

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/entry/BookEntryScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/entry/BookEntryScreen.java
@@ -348,11 +348,6 @@ public abstract class BookEntryScreen extends BookPaginatedScreen implements Con
         this.updateBookmarksButton();
     }
 
-    @Override
-    public boolean canSeeBackButton() {
-        return true;
-    }
-
     protected boolean isBookmarked() {
         return BookVisualStateManager.get().getBookmarksFor(this.minecraft.player, this.entry.getBook()).stream().anyMatch(b -> b.entryId().equals(this.entry.getId()));
     }

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/entry/BookEntryScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/entry/BookEntryScreen.java
@@ -348,6 +348,11 @@ public abstract class BookEntryScreen extends BookPaginatedScreen implements Con
         this.updateBookmarksButton();
     }
 
+    @Override
+    public boolean canSeeBackButton() {
+        return true;
+    }
+
     protected boolean isBookmarked() {
         return BookVisualStateManager.get().getBookmarksFor(this.minecraft.player, this.entry.getBook()).stream().anyMatch(b -> b.entryId().equals(this.entry.getId()));
     }


### PR DESCRIPTION
## Summary
- keep the entry back button visible on book entry screens
- treat the back button as entry-history navigation rather than page-navigation state
- fixes #342 where the next-page control was visible but the back button disappeared

## Verification
- ./gradlew.bat :common:compileJava