### PR TITLE
fix: re-enable JEI integration for 26.1.1

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,14 +22,6 @@ loom {
     }
 }
 
-sourceSets {
-    main {
-        java {
-            exclude '**/jei/ModonomiconJeiIntegrationImpl.java'
-        }
-    }
-}
-
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
 
@@ -37,7 +29,7 @@ dependencies {
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: "${jsr305_version}"
 
 //    Jei
-//    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
 
     //commonmark
     //here we just need to add it to the classpaths, forge/fabric will put it in the jar for distribution

--- a/common/src/main/java/com/klikli_dev/modonomicon/integration/jei/ModonomiconJeiIntegration.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/integration/jei/ModonomiconJeiIntegration.java
@@ -6,14 +6,29 @@
 
 package com.klikli_dev.modonomicon.integration.jei;
 
+import com.klikli_dev.modonomicon.Modonomicon;
+import com.klikli_dev.modonomicon.platform.Services;
 import net.minecraft.world.item.ItemStack;
 
 public interface ModonomiconJeiIntegration {
 
-    ModonomiconJeiIntegration instance = new ModonomiconJeiIntegrationDummy();
-
     static ModonomiconJeiIntegration get() {
-        return instance;
+        return Holder.INSTANCE;
+    }
+
+    private static ModonomiconJeiIntegration create() {
+        if (!Services.PLATFORM.isModLoaded("jei")) {
+            return new ModonomiconJeiIntegrationDummy();
+        }
+
+        try {
+            return (ModonomiconJeiIntegration) Class.forName("com.klikli_dev.modonomicon.integration.jei.ModonomiconJeiIntegrationImpl")
+                    .getDeclaredConstructor()
+                    .newInstance();
+        } catch (ReflectiveOperationException | LinkageError e) {
+            Modonomicon.LOG.warn("Failed to initialize JEI integration, falling back to dummy implementation.", e);
+            return new ModonomiconJeiIntegrationDummy();
+        }
     }
 
     boolean isLoaded();
@@ -23,4 +38,11 @@ public interface ModonomiconJeiIntegration {
     void showRecipe(ItemStack stack);
 
     void showUses(ItemStack stack);
+
+    final class Holder {
+        private static final ModonomiconJeiIntegration INSTANCE = create();
+
+        private Holder() {
+        }
+    }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -29,9 +29,9 @@ dependencies {
     //implementation project(path: ":common", configuration: "namedElements")
 
     //Jei
-//    modCompileOnlyApi ("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
-//    modCompileOnlyApi ("mezz.jei:jei-${minecraft_version}-fabric-api:${jei_version}")
-//    modRuntimeOnly ("mezz.jei:jei-${minecraft_version}-fabric:${jei_version}")
+    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-fabric-api:${jei_version}"
+    runtimeOnly "mezz.jei:jei-${minecraft_version}-fabric:${jei_version}"
 
     //commonmark
     //make it available for compile/runtime classpath

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -93,9 +93,9 @@ dependencies {
     compileOnly project(":common")
 
     //Jei
-//    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
-//    compileOnly "mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}"
-//    runtimeOnly "mezz.jei:jei-${minecraft_version}-forge:${jei_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}"
+    runtimeOnly "mezz.jei:jei-${minecraft_version}-forge:${jei_version}"
 
 //    implementation "vazkii.patchouli:Patchouli:${minecraft_version}-${patchouli_version}-FORGE"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ org.gradle.daemon=false
 
 # The Minecraft version must agree with the Forge version to get a valid artifact
 minecraft_version=26.1.1
+minecraft_major_version=26.1
 # The Minecraft version range can use any release version of Minecraft as bounds.
 # Snapshots, pre-releases, and release candidates are not guaranteed to sort properly
 # as they do not follow standard versioning conventions.
@@ -52,7 +53,7 @@ mod_description=Data-driven minecraft in-game documentation with progress visual
 ## Dependency Properties
 
 # Mods
-jei_version=19.8.5.118
+jei_version=29.4.0.23
 patchouli_version=TODO
 
 # Libraries

--- a/neo/build.gradle
+++ b/neo/build.gradle
@@ -63,9 +63,9 @@ dependencies {
     compileOnly project(":common")
 
     //Jei
-//    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
-//    compileOnly "mezz.jei:jei-${minecraft_version}-neoforge-api:${jei_version}"
-//    localRuntime "mezz.jei:jei-${minecraft_version}-neoforge:${jei_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-neoforge-api:${jei_version}"
+    localRuntime "mezz.jei:jei-${minecraft_version}-neoforge:${jei_version}"
 
 //    implementation "vazkii.patchouli:Patchouli:${minecraft_version}-${patchouli_version}-FORGE"
 


### PR DESCRIPTION
## Summary
- re-enable JEI dependencies for the 26.1.1 line using the latest 29.4.0.23 artifacts
- remove the common JEI source exclusion and lazy-load the real integration when JEI is present
- keep Fabric, NeoForge, and Forge build declarations in sync while preserving successful common/fabric/neo compilation
