### PR TITLE
fix: restore default book text color styling

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/BookTextRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/BookTextRenderer.java
@@ -60,6 +60,7 @@ public class BookTextRenderer {
                 .renderSoftLineBreaks(false)
                 .replaceSoftLineBreaksWithSpace(true)
                 .linkColor(TextColor.fromRgb(0x5555FF))
+                .defaultTextColor(TextColor.fromRgb(this.book.getDefaultTextColor()))
                 .linkRenderers(List.of(
                         new ColorLinkRenderer(),
                         new BookLinkRenderer(),

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/ComponentNodeRendererContext.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/ComponentNodeRendererContext.java
@@ -100,6 +100,11 @@ public interface ComponentNodeRendererContext {
     TextColor getLinkColor();
 
     /**
+     * The default text color for the book.
+     */
+    TextColor getDefaultTextColor();
+
+    /**
      * Gets the link renderers for the component renderer. These are used to create additional markdown functionality by
      * (ab)using the link syntax.
      */

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/ComponentRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/ComponentRenderer.java
@@ -31,6 +31,7 @@ public class ComponentRenderer {
     private final boolean renderSoftLineBreaks;
     private final boolean replaceSoftLineBreaksWithSpace;
     private final TextColor linkColor;
+    private final TextColor defaultTextColor;
     private MutableComponent currentComponent;
     private Style currentStyle;
     private ListHolder listHolder;
@@ -39,6 +40,7 @@ public class ComponentRenderer {
         this.renderSoftLineBreaks = builder.renderSoftLineBreaks;
         this.replaceSoftLineBreaksWithSpace = builder.replaceSoftLineBreaksWithSpace;
         this.linkColor = builder.linkColor;
+        this.defaultTextColor = builder.defaultTextColor;
         this.currentStyle = builder.style;
         this.linkRenderers = builder.linkRenderers;
 
@@ -84,6 +86,7 @@ public class ComponentRenderer {
         private boolean renderSoftLineBreaks = false;
         private boolean replaceSoftLineBreaksWithSpace = true;
         private TextColor linkColor = TextColor.fromRgb(0x5555FF);
+        private TextColor defaultTextColor = TextColor.fromRgb(0x000000);
         private Style style = Style.EMPTY;
 
         /**
@@ -115,6 +118,14 @@ public class ComponentRenderer {
          */
         public ComponentRenderer.Builder linkColor(TextColor linkColor) {
             this.linkColor = linkColor;
+            return this;
+        }
+
+        /**
+         * The default text color for the book.
+         */
+        public ComponentRenderer.Builder defaultTextColor(TextColor defaultTextColor) {
+            this.defaultTextColor = defaultTextColor;
             return this;
         }
 
@@ -255,6 +266,11 @@ public class ComponentRenderer {
         @Override
         public TextColor getLinkColor() {
             return ComponentRenderer.this.linkColor;
+        }
+
+        @Override
+        public TextColor getDefaultTextColor() {
+            return ComponentRenderer.this.defaultTextColor;
         }
 
         @Override

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/CoreComponentNodeRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/markdown/CoreComponentNodeRenderer.java
@@ -195,8 +195,12 @@ public class CoreComponentNodeRenderer extends AbstractVisitor implements NodeRe
 
     @Override
     public void visit(Text text) {
+        var style = this.context.getCurrentStyle();
+        if (style.getColor() == null) {
+            style = style.withColor(this.context.getDefaultTextColor());
+        }
         this.context.getCurrentComponent().append(
-                Component.translatable(text.getLiteral()).withStyle(this.context.getCurrentStyle()));
+                Component.translatable(text.getLiteral()).withStyle(style));
         this.visitChildren(text);
     }
 


### PR DESCRIPTION
## Summary
- thread the book default text color through the markdown component renderer context
- apply the default color only when emitting plain text nodes without an explicit color
- preserve existing link renderer fallback behavior that depends on a null current style color

## Verification
- ./gradlew :common:compileJava