### PR TITLE
fix: restore index overview widget layout

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/index/BookParentIndexScreen.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/gui/book/index/BookParentIndexScreen.java
@@ -100,6 +100,7 @@ public class BookParentIndexScreen extends BookPaginatedScreen implements BookPa
     }
 
     protected void drawTitle(GuiGraphicsExtractor guiGraphics, int x, int y){
+        guiGraphics.pose().pushMatrix();
         var scale = Math.min(1.0f, (float) BookEntryScreen.MAX_TITLE_WIDTH / (float) this.font.width(this.getTitle()));
         if (scale < 1) {
             guiGraphics.pose().translate(x - x * scale, y - y * scale);
@@ -108,6 +109,7 @@ public class BookParentIndexScreen extends BookPaginatedScreen implements BookPa
 
         //we use scale 1 because our scale translation handling in there is off a bit. the above translation code is better
         this.drawCenteredStringNoShadow(guiGraphics, this.getTitle(), x, y, this.getBook().getDefaultTitleColor(), 1);
+        guiGraphics.pose().popMatrix();
     }
 
     public void drawCenteredStringNoShadow(GuiGraphicsExtractor guiGraphics, Component s, int x, int y, int color) {
@@ -228,8 +230,7 @@ public class BookParentIndexScreen extends BookPaginatedScreen implements BookPa
 
         this.resetTooltip();
 
-        //we need to modify blit offset (now: z pose) to not draw over toasts
-        //TODO we had -1300z here
+        guiGraphics.pose().pushMatrix();
         guiGraphics.pose().translate(this.bookLeft, this.bookTop);
 
         BookContentRenderer.renderBookBackground(guiGraphics, this.getBook().getBookContentTexture());
@@ -260,6 +261,8 @@ public class BookParentIndexScreen extends BookPaginatedScreen implements BookPa
                         this.book.getDefaultTextColor());
             }
         }
+
+        guiGraphics.pose().popMatrix();
 
         //do not translate super (= widget rendering) -> otherwise our buttons are messed up
         //manually call the renderables like super does -> otherwise super renders the background again on top of our stuff


### PR DESCRIPTION
## Summary
- restore pose stack scoping in BookParentIndexScreen so book-local translation does not leak into widget rendering
- isolate title scaling the same way as the working 1.21.1 implementation and sibling index/search screens
- keep the temporary demo ook.json testing change out of the fix