### PR TITLE
feat: extract JEI subtype interpreter into dedicated class

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/book/conditions/BookCondition.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/book/conditions/BookCondition.java
@@ -45,18 +45,6 @@ public abstract class BookCondition {
         this.tooltip = tooltip;
     }
 
-    public static MutableComponent tooltipFromJson(JsonObject json, HolderLookup.Provider provider) {
-        if (json.has("tooltip")) {
-            var tooltipElement = json.get("tooltip");
-            if (tooltipElement.isJsonPrimitive()) {
-                return Component.translatable(tooltipElement.getAsString());
-            }
-
-            return Component.literal("").append(ComponentSerialization.CODEC.parse(provider.createSerializationContext(JsonOps.INSTANCE), tooltipElement).getOrThrow());
-        }
-        return null;
-    }
-
     public static BookCondition fromJson(Identifier conditionParentId, JsonObject json, HolderLookup.Provider provider) {
         return CODEC.parse(provider.createSerializationContext(JsonOps.INSTANCE), json)
                 .getOrThrow(error -> new IllegalArgumentException("Failed to decode condition for " + conditionParentId + ": " + error));

--- a/common/src/main/java/com/klikli_dev/modonomicon/book/conditions/BookOrCondition.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/book/conditions/BookOrCondition.java
@@ -42,8 +42,8 @@ public class BookOrCondition extends BookCondition {
 
     protected List<Component> tooltips;
 
-    public BookOrCondition(Component component, BookCondition[] children) {
-        super(component);
+    public BookOrCondition(Component tooltip, BookCondition[] children) {
+        super(tooltip);
         if (children == null || children.length == 0)
             throw new IllegalArgumentException("OrCondition must have at least one child.");
 

--- a/common/src/main/java/com/klikli_dev/modonomicon/integration/jei/ModonomiconJeiIntegrationImpl.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/integration/jei/ModonomiconJeiIntegrationImpl.java
@@ -8,7 +8,6 @@ import com.klikli_dev.modonomicon.Modonomicon;
 import com.klikli_dev.modonomicon.api.ModonomiconAPI;
 import com.klikli_dev.modonomicon.platform.ClientServices;
 import com.klikli_dev.modonomicon.platform.Services;
-import com.klikli_dev.modonomicon.registry.DataComponentRegistry;
 import com.klikli_dev.modonomicon.registry.ItemRegistry;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
@@ -91,13 +90,7 @@ public class ModonomiconJeiIntegrationImpl implements ModonomiconJeiIntegration 
 
         @Override
         public void registerItemSubtypes(@NotNull ISubtypeRegistration registration) {
-
-            registration.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, ItemRegistry.MODONOMICON.get(), (stack, context) -> {
-                if (!stack.has(DataComponentRegistry.BOOK_ID.get())) {
-                    return "";
-                }
-                return stack.get(DataComponentRegistry.BOOK_ID.get()).toString();
-            });
+            registration.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, ItemRegistry.MODONOMICON.get(), ModonomiconSubtypeInterpreter.get());
         }
     }
 }

--- a/common/src/main/java/com/klikli_dev/modonomicon/integration/jei/ModonomiconSubtypeInterpreter.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/integration/jei/ModonomiconSubtypeInterpreter.java
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.modonomicon.integration.jei;
+
+import com.klikli_dev.modonomicon.registry.DataComponentRegistry;
+import mezz.jei.api.ingredients.subtypes.ISubtypeInterpreter;
+import mezz.jei.api.ingredients.subtypes.UidContext;
+import net.minecraft.world.item.ItemStack;
+
+public class ModonomiconSubtypeInterpreter implements ISubtypeInterpreter<ItemStack> {
+
+    private static final ModonomiconSubtypeInterpreter instance = new ModonomiconSubtypeInterpreter();
+
+    public static ModonomiconSubtypeInterpreter get() {
+        return instance;
+    }
+
+    @Override
+    public Object getSubtypeData(ItemStack ingredient, UidContext context) {
+        if (!ingredient.has(DataComponentRegistry.BOOK_ID.get())) {
+            return "";
+        }
+        return ingredient.get(DataComponentRegistry.BOOK_ID.get()).toString();
+    }
+}


### PR DESCRIPTION
Extract the inline lambda from ModonomiconJeiPlugin.registerItemSubtypes() into a standalone ModonomiconSubtypeInterpreter class following the pattern used in the Theurgy mod (DivinationRodSubtypeInterpreter). The interpreter uses the BOOK_ID data component to determine the JEI subtype for the modonomicon item.