### PR TITLE
feat(research): advancement reconciliation after reset and on player login

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/command/ResetResearchCommand.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/command/ResetResearchCommand.java
@@ -35,6 +35,8 @@ public class ResetResearchCommand implements com.mojang.brigadier.Command<Comman
         var player = context.getSource().getPlayer();
         var before = BookDataManager.get().getBooks().values().stream().collect(java.util.stream.Collectors.toMap(Book::getId, book -> BookVisibilitySnapshots.collect(player, book)));
         ResearchServices.state().resetFor(player);
+        // Replay advancement-backed hooks so advancement-earned research is restored immediately.
+        ResearchServices.advancements().replayAll(player);
         for (var book : BookDataManager.get().getBooks().values()) {
             BookVisualStateManager.get().updateVisibilityDrivenUnread(player, book, before.get(book.getId()), BookVisibilitySnapshots.collect(player, book));
         }

--- a/common/src/main/java/com/klikli_dev/modonomicon/research/hook/AdvancementResearchHookService.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/research/hook/AdvancementResearchHookService.java
@@ -25,6 +25,62 @@ public class AdvancementResearchHookService {
         this.stateManager = stateManager;
     }
 
+    /**
+     * Replays all advancement-backed hooks against the player's current advancement progress.
+     * Used after research reset and on player login to restore advancement-backed research state.
+     *
+     * @return true if any research state changed
+     */
+    public boolean replayAll(ServerPlayer player) {
+        var before = BookDataManager.get().getBooks().values().stream()
+                .collect(java.util.stream.Collectors.toMap(Book::getId, book -> BookVisibilitySnapshots.collect(player, book)));
+        boolean changed = false;
+        var serverAdvancements = player.level().getServer().getAdvancements();
+        var playerAdvancements = player.getAdvancements();
+        for (var entry : ResearchDataManager.get().data().advancementHooks().entrySet()) {
+            var advancementId = entry.getKey();
+            var hooks = entry.getValue();
+            var holder = serverAdvancements.get(advancementId);
+            if (holder == null) {
+                continue; // advancement removed from datapack, skip
+            }
+            var progress = playerAdvancements.getOrStartProgress(holder);
+            if (!progress.isDone()) {
+                continue; // advancement not yet completed, skip
+            }
+            for (var hook : hooks) {
+                if (hook.factId() != null) {
+                    changed |= this.stateManager.grantFact(player, hook.factId());
+                } else if (hook.valueId() != null) {
+                    changed |= this.stateManager.incrementValue(player, hook.valueId(), hook.increment());
+                }
+            }
+        }
+        if (changed) {
+            changed |= this.stateManager.reevaluate(player);
+            for (var book : BookDataManager.get().getBooks().values()) {
+                BookVisualStateManager.get().updateVisibilityDrivenUnread(player, book, before.get(book.getId()), BookVisibilitySnapshots.collect(player, book));
+            }
+        }
+        return changed;
+    }
+
+    /**
+     * Checks whether the player's research state is missing any advancement-backed facts.
+     * If so, the state was likely reset and advancement hooks need to be replayed.
+     */
+    public boolean needsAdvancementReplay(ServerPlayer player) {
+        var state = this.stateManager.getStateFor(player);
+        for (var hooks : ResearchDataManager.get().data().advancementHooks().values()) {
+            for (var hook : hooks) {
+                if (hook.factId() != null && !state.hasFact(hook.factId())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     public boolean onAdvancement(ServerPlayer player, Identifier advancementId) {
         var before = BookDataManager.get().getBooks().values().stream().collect(java.util.stream.Collectors.toMap(Book::getId, book -> BookVisibilitySnapshots.collect(player, book)));
         boolean changed = false;

--- a/docs/spec/2026-05-28-research-system-revised-design.md
+++ b/docs/spec/2026-05-28-research-system-revised-design.md
@@ -390,6 +390,7 @@ Completed so far:
 - values demo scenario (collector: 3 incrementing entries + 1 threshold-gated entry)
 - item crafted demo scenario (crafting stick → unlock entry)
 - item acquired demo scenario (acquire cobblestone → unlock entry)
+- advancement reconciliation: replay completed advancement hooks after reset and on player login
 - typed refs: `ResearchFactRef`, `ResearchNodeRef`, `ResearchValueRef`
 - research-side datagen builder API (`ResearchDataBuilder`, `ResearchIngressHelper`)
 - `ingress()` fluent helper with `onEntryViewedOnce`, `onAdvancementEarned`, `onItemCrafted`, `onItemAcquired`, `declareFact`, `grantFact`
@@ -405,7 +406,6 @@ Not completed yet:
 - datapack patch/merge semantics
 - research-side optional-dependency predicate for optional dependency mods
 - sanctioned research skip/bypass mechanism for narrow scenarios
-- advancement reconciliation on reset/login (replay already-completed advancements)
 
 ## Roadmap
 

--- a/docs/spec/2026-05-28-research-system-revised-design.md
+++ b/docs/spec/2026-05-28-research-system-revised-design.md
@@ -364,6 +364,8 @@ Completed so far:
 - Phase 1 foundation for facts, nodes, hooks, persistence, and validation
 - trigger type `entry_viewed_once`
 - trigger type registry (extensible trigger type infrastructure)
+- trigger type `item_crafted` (manual crafting only, output item ID)
+- trigger type `item_acquired` (inventory change, item ID)
 - book condition type `research_node_unlocked`
 - demo entry slice for:
   - `modonomicon:features/condition_root`
@@ -386,9 +388,11 @@ Completed so far:
 - research progress button replacing the old read-all progression shortcut
 - research values (numeric counters) with hook increment and node threshold support
 - values demo scenario (collector: 3 incrementing entries + 1 threshold-gated entry)
+- item crafted demo scenario (crafting stick → unlock entry)
+- item acquired demo scenario (acquire cobblestone → unlock entry)
 - typed refs: `ResearchFactRef`, `ResearchNodeRef`, `ResearchValueRef`
 - research-side datagen builder API (`ResearchDataBuilder`, `ResearchIngressHelper`)
-- `ingress()` fluent helper with `onEntryViewedOnce`, `onAdvancementEarned`, `declareFact`, `grantFact`
+- `ingress()` fluent helper with `onEntryViewedOnce`, `onAdvancementEarned`, `onItemCrafted`, `onItemAcquired`, `declareFact`, `grantFact`
 - `ResearchProvider` / `ResearchSubProvider` / `SingleResearchSubProvider` datagen API
 - platform datagen wrappers and registrations
 - elimination of `ModonomiconDataGenSetup` orchestrator; direct cache passing
@@ -398,8 +402,6 @@ Completed so far:
 
 Not completed yet:
 
-- additional trigger families such as `item_crafted` and `item_acquired`
-- broader non-demo authored-content migration and validation beyond the demo/cutover slices already completed
 - datapack patch/merge semantics
 - research-side optional-dependency predicate for optional dependency mods
 - sanctioned research skip/bypass mechanism for narrow scenarios
@@ -435,7 +437,6 @@ Current status:
 - completed for `ResearchProvider` / subprovider datagen API
 - completed for book-side research glue and `BookHierarchyResearchCompiler`
 - completed for elimination of `ModonomiconDataGenSetup` orchestrator
-- still not proven for broader non-demo authored content
 
 Not part of phase 1:
 
@@ -450,10 +451,6 @@ Completed post-phase-1 slices (completed out of original order):
 - trigger type registry infrastructure
 - `ModonomiconDataGenSetup` elimination
 
-Recommended next slice:
-
-- add `item_crafted` trigger type (Phase 2)
-
 ### Phase 2: Explicit Trigger Expansion
 
 Phase 2 broadens the explicit model without introducing major sugar.
@@ -465,13 +462,13 @@ Included:
 - expanded explicit validation and diagnostics for hooks/resources
 - any admin/debug improvements that naturally extend the explicit runtime model
 
-Recommended first slice in phase 2:
+Current status:
 
-- add `item_crafted` only
-- keep it explicit and fact-backed
-- prove it in one narrow authored scenario before adding `item_acquired`
-
-Note: value-based progression was completed ahead of phase 2 and is already proven stable.
+- completed for `item_crafted` trigger type (manual crafting only, output item ID)
+- completed for `item_acquired` trigger type (inventory change, item ID)
+- completed for platform wiring (NeoForge events, Forge events, Fabric mixins)
+- completed for datagen hook specs, ingress helpers, and builder methods
+- completed for demo scenarios (crafting stick, acquiring cobblestone)
 
 Not part of phase 2 unless strictly needed:
 
@@ -493,7 +490,7 @@ Completed:
 Still planned:
 
 - convenience helpers around viewed-once and later triggers
-- broader trigger families (`item_crafted`, `item_acquired`, etc.)
+- broader trigger families beyond Phase 2 (e.g. `dimension_visited`, `custom_api_trigger`)
 - datapack patch/merge semantics
 
 All later convenience must compile to the same canonical explicit model introduced in phase 1.

--- a/fabric/src/main/java/com/klikli_dev/modonomicon/ModonomiconFabric.java
+++ b/fabric/src/main/java/com/klikli_dev/modonomicon/ModonomiconFabric.java
@@ -11,6 +11,7 @@ import com.klikli_dev.modonomicon.bookstate.BookVisualStateManager;
 import com.klikli_dev.modonomicon.config.ServerConfig;
 import com.klikli_dev.modonomicon.data.BookDataManager;
 import com.klikli_dev.modonomicon.data.MultiblockDataManager;
+import com.klikli_dev.modonomicon.research.ResearchServices;
 import com.klikli_dev.modonomicon.research.data.ResearchDataManager;
 import com.klikli_dev.modonomicon.research.state.ResearchStateManager;
 import com.klikli_dev.modonomicon.registry.RegistryBootstrap;
@@ -32,6 +33,7 @@ import net.fabricmc.fabric.api.resource.v1.ResourceLoader;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.packs.PackType;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 
 public class ModonomiconFabric implements ModInitializer {
@@ -87,6 +89,14 @@ public class ModonomiconFabric implements ModInitializer {
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
             BookVisualStateManager.get().syncFor(handler.getPlayer());
             ResearchStateManager.get().onDatapackSync(handler.getPlayer());
+            // Replay advancement-backed hooks if research state is stale (e.g. reset while offline).
+            if (handler.getPlayer() instanceof ServerPlayer player) {
+                if (ResearchServices.advancements().needsAdvancementReplay(player)) {
+                    ResearchServices.advancements().replayAll(player);
+                    ResearchStateManager.get().syncFor(player);
+                    BookVisualStateManager.get().syncFor(player);
+                }
+            }
         });
 
         //on overworld unload clear the save data reference in the state manager

--- a/forge/src/main/java/com/klikli_dev/modonomicon/ModonomiconForge.java
+++ b/forge/src/main/java/com/klikli_dev/modonomicon/ModonomiconForge.java
@@ -110,6 +110,12 @@ public class ModonomiconForge {
             if (e.getEntity() instanceof ServerPlayer player) {
                 BookVisualStateManager.get().syncFor(player);
                 ResearchStateManager.get().onDatapackSync(player);
+                // Replay advancement-backed hooks if research state is stale (e.g. reset while offline).
+                if (ResearchServices.advancements().needsAdvancementReplay(player)) {
+                    ResearchServices.advancements().replayAll(player);
+                    ResearchStateManager.get().syncFor(player);
+                    BookVisualStateManager.get().syncFor(player);
+                }
             }
         });
 

--- a/neo/src/main/java/com/klikli_dev/modonomicon/ModonomiconNeo.java
+++ b/neo/src/main/java/com/klikli_dev/modonomicon/ModonomiconNeo.java
@@ -115,6 +115,12 @@ public class ModonomiconNeo {
             if (e.getEntity() instanceof ServerPlayer player) {
                 BookVisualStateManager.get().syncFor(player);
                 ResearchStateManager.get().onDatapackSync(player);
+                // Replay advancement-backed hooks if research state is stale (e.g. reset while offline).
+                if (ResearchServices.advancements().needsAdvancementReplay(player)) {
+                    ResearchServices.advancements().replayAll(player);
+                    ResearchStateManager.get().syncFor(player);
+                    BookVisualStateManager.get().syncFor(player);
+                }
             }
         });
 


### PR DESCRIPTION
Adds advancement hook replay so that advancement-backed research state is restored after a research reset or when a player joins with stale state.

Changes:
- AdvancementResearchHookService: add eplayAll and 
eedsAdvancementReplay methods
- ResetResearchCommand: call eplayAll after reset
- NeoForge/Forge/Fabric join handlers: call eplayAll when advancement-backed facts are missing from loaded state
- Update spec to mark advancement reconciliation as completed