### PR TITLE
Fix incorrect buffer batching in multiblock preview rendering on 1.21.1

### DIFF
--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/MultiblockPreviewRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/MultiblockPreviewRenderer.java
@@ -250,8 +250,8 @@ public class MultiblockPreviewRenderer {
         ms.pushPose();
         ms.translate(-renderPosX, -renderPosY, -renderPosZ);
 
-		var mainBuffers = mc.renderBuffers().bufferSource();
-		mainBuffers.endBatch(); // when we do initBuffers we keep the buffers but dont know if were still batching, so it doesnt properly end in the getBuffer call and breaks stuff
+        var mainBuffers = mc.renderBuffers().bufferSource();
+        mainBuffers.endBatch(); // when we do initBuffers we keep the buffers but dont know if were still batching, so it doesnt properly end in the getBuffer call and breaks stuff
         if (buffers == null) {
             buffers = initBuffers(mainBuffers);
         }

--- a/common/src/main/java/com/klikli_dev/modonomicon/client/render/MultiblockPreviewRenderer.java
+++ b/common/src/main/java/com/klikli_dev/modonomicon/client/render/MultiblockPreviewRenderer.java
@@ -250,8 +250,10 @@ public class MultiblockPreviewRenderer {
         ms.pushPose();
         ms.translate(-renderPosX, -renderPosY, -renderPosZ);
 
+		var mainBuffers = mc.renderBuffers().bufferSource();
+		mainBuffers.endBatch(); // when we do initBuffers we keep the buffers but dont know if were still batching, so it doesnt properly end in the getBuffer call and breaks stuff
         if (buffers == null) {
-            buffers = initBuffers(mc.renderBuffers().bufferSource());
+            buffers = initBuffers(mainBuffers);
         }
 
         BlockPos checkPos = null;


### PR DESCRIPTION
<img width="1920" height="1057" alt="image" src="https://github.com/user-attachments/assets/0f231369-6eaf-45d0-a975-be79d740f327" />
<img width="1920" height="1057" alt="image" src="https://github.com/user-attachments/assets/5f399f9a-234a-48ae-8ed8-7041015c7cfa" />
fixes rendering issues, particularly those revealed by interactions with apotheosis or anything else that uses the neoforge AFTER_TRIPWIRE rendering stage?
idk if this is a problem w other loaders, i only tested the issue and fix on neoforge...
fixes #339 in my testing
for reference heres what it looked like before
<img width="1271" height="1041" alt="image" src="https://github.com/user-attachments/assets/65582415-32ee-4337-b4fb-9ac291bc968b" />
